### PR TITLE
Changed the UUID characteristic to UUIDString

### DIFF
--- a/library/src/iosMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt
+++ b/library/src/iosMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt
@@ -8,7 +8,7 @@ import platform.posix.memcpy
 
 actual class BluetoothCharacteristic(val characteristic: CBCharacteristic) {
     actual val name: String?
-        get() = characteristic.UUID.description()
+        get() = characteristic.UUID.UUIDString
     actual val value: ByteArray?
         get() = characteristic.value?.let { data ->
             ByteArray(data.length.toInt()).apply {


### PR DESCRIPTION
I don't know if the UUID of the characteristic was intentionally put to be its description. Currently, the description value is displayed (which can be the UUIDString or even the feature characteristic - in my project, is displayed the name), which is quite difficult when you need the characteristic ID and not its name.