### PR TITLE
Writing to the characteristic without any encoding

### DIFF
--- a/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -170,6 +170,15 @@ actual class BlueFalcon actual constructor(
         }
     }
 
+    actual fun writeCharacteristicWithoutEncoding(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        value: ByteArray,
+        writeType: Int?
+    ) {
+        writeCharacteristic(bluetoothPeripheral, bluetoothCharacteristic, value, writeType)
+    }
+
     actual fun writeCharacteristic(
         bluetoothPeripheral: BluetoothPeripheral,
         bluetoothCharacteristic: BluetoothCharacteristic,

--- a/library/src/commonMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/commonMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -56,6 +56,13 @@ expect class BlueFalcon(context: ApplicationContext, serviceUUID: String?) {
         writeType: Int?
     )
 
+    fun writeCharacteristicWithoutEncoding(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        value: ByteArray,
+        writeType: Int?
+    )
+
     fun readDescriptor(
         bluetoothPeripheral: BluetoothPeripheral,
         bluetoothCharacteristic: BluetoothCharacteristic,

--- a/library/src/iosMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/iosMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -111,11 +111,25 @@ actual class BlueFalcon actual constructor(
         bluetoothCharacteristic: BluetoothCharacteristic,
         value: ByteArray,
         writeType: Int?
-    ){
+    ) {
         sharedWriteCharacteristic(
             bluetoothPeripheral,
             bluetoothCharacteristic,
             NSString.create(string = value.decodeToString()),
+            writeType
+        )
+    }
+
+    actual fun writeCharacteristicWithoutEncoding(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        value: ByteArray,
+        writeType: Int?
+    ) {
+        sharedWriteCharacteristic(
+            bluetoothPeripheral,
+            bluetoothCharacteristic,
+            value.toData(),
             writeType
         )
     }
@@ -127,15 +141,29 @@ actual class BlueFalcon actual constructor(
         writeType: Int?
     ) {
         value.dataUsingEncoding(NSUTF8StringEncoding)?.let {
-            bluetoothPeripheral.bluetoothDevice.writeValue(
+            sharedWriteCharacteristic(
+                bluetoothPeripheral,
+                bluetoothCharacteristic,
                 it,
-                bluetoothCharacteristic.characteristic,
-                when (writeType) {
-                    1 -> CBCharacteristicWriteWithoutResponse
-                    else -> CBCharacteristicWriteWithResponse
-                }
+                writeType
             )
         }
+    }
+
+    private fun sharedWriteCharacteristic(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        value: NSData,
+        writeType: Int?
+    ) {
+        bluetoothPeripheral.bluetoothDevice.writeValue(
+            value,
+            bluetoothCharacteristic.characteristic,
+            when (writeType) {
+                1 -> CBCharacteristicWriteWithoutResponse
+                else -> CBCharacteristicWriteWithResponse
+            }
+        )
     }
 
     actual fun readDescriptor(

--- a/library/src/iosMain/kotlin/dev/bluefalcon/NSData.kt
+++ b/library/src/iosMain/kotlin/dev/bluefalcon/NSData.kt
@@ -1,7 +1,16 @@
 package dev.bluefalcon
 
+import kotlinx.cinterop.allocArrayOf
+import kotlinx.cinterop.memScoped
 import platform.Foundation.*
+import kotlinx.cinterop.allocArrayOf
+import kotlinx.cinterop.memScoped
 
 fun NSData.string(): String? {
     return NSString.create(this, NSUTF8StringEncoding) as String?
+}
+
+fun ByteArray.toData(): NSData = memScoped {
+    NSData.create(bytes = allocArrayOf(this@toData),
+        length = this@toData.size.toULong())
 }


### PR DESCRIPTION
Fixes #79 
 
In the current implementation, the byte array goes through several processes before being sent to the server (decode, encode). This breaks the converted value into a byte array, in the order of Little Endian. I added the option to send the array without the need to decode and encode again the array.