### PR TITLE
Added .toData extension for macosX64

### DIFF
--- a/library/src/macosX64Main/kotlin/dev/bluefalcon/NSData.kt
+++ b/library/src/macosX64Main/kotlin/dev/bluefalcon/NSData.kt
@@ -1,7 +1,16 @@
 package dev.bluefalcon
 
+import kotlinx.cinterop.allocArrayOf
+import kotlinx.cinterop.memScoped
 import platform.Foundation.*
+import kotlinx.cinterop.allocArrayOf
+import kotlinx.cinterop.memScoped
 
 fun NSData.string(): String? {
     return NSString.create(this, NSUTF8StringEncoding) as String?
+}
+
+fun ByteArray.toData(): NSData = memScoped {
+    NSData.create(bytes = allocArrayOf(this@toData),
+        length = this@toData.size.toULong())
 }


### PR DESCRIPTION
Added .toData extension for macosX64. Is strange because on my side, I didn't have any crash crashes