### PR TITLE
:sparkles: Add callback for didWrite

### DIFF
--- a/examples/Android-Example/src/main/java/dev/bluefalcon/services/BluetoothService.kt
+++ b/examples/Android-Example/src/main/java/dev/bluefalcon/services/BluetoothService.kt
@@ -105,6 +105,13 @@ class BluetoothService: BlueFalconDelegate {
     override fun didDiscoverCharacteristics(bluetoothPeripheral: BluetoothPeripheral) {}
 
     override fun didUpdateMTU(bluetoothPeripheral: BluetoothPeripheral) {}
+    override fun didWriteCharacteristic(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        success: Boolean
+    ) {
+        print("didWriteCharacteristic $bluetoothCharacteristic --> success: $success")
+    }
 
 }
 

--- a/examples/MacOS-Example/MacOS-Example/Services/BluetoothService.swift
+++ b/examples/MacOS-Example/MacOS-Example/Services/BluetoothService.swift
@@ -158,6 +158,10 @@ extension BluetoothService: BlueFalconDelegate {
 
     func didUpdateMTU(bluetoothPeripheral: BluetoothPeripheral) {}
 
+    func didWriteCharacteristic(bluetoothPeripheral: BluetoothPeripheral, bluetoothCharacteristic: BluetoothCharacteristic, success: Bool) {
+        print("BT Service didWriteCharacteristic -> success: \(success)")
+    }
+    
     private func bluetoothServiceConnectedDeviceDelegates(bluetoothPeripheralId: UUID) -> [BluetoothServiceConnectedDeviceDelegate] {
         return connectedDeviceDelegates.compactMap { connectedDeviceDelegateTuple -> BluetoothServiceConnectedDeviceDelegate? in
             connectedDeviceDelegateTuple.0 == bluetoothPeripheralId ? connectedDeviceDelegateTuple.1 : nil

--- a/examples/iOS-Example/iOS-Example.xcodeproj/project.pbxproj
+++ b/examples/iOS-Example/iOS-Example.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		493EC0BB25EA453A009E1801 /* Descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493EC0A725EA453A009E1801 /* Descriptor.swift */; };
 		493EC0BC25EA453A009E1801 /* BluetoothScanningState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493EC0A825EA453A009E1801 /* BluetoothScanningState.swift */; };
 		4980A9A628009D6F0049F236 /* BlueFalcon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4980A9A528009D6F0049F236 /* BlueFalcon.xcframework */; };
-		4980A9A728009D6F0049F236 /* BlueFalcon.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4980A9A528009D6F0049F236 /* BlueFalcon.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C433643F28102A7700601205 /* BlueFalcon.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C4E3D6BD2801599E00D048C1 /* BlueFalcon.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -42,7 +42,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				4980A9A728009D6F0049F236 /* BlueFalcon.xcframework in Embed Frameworks */,
+				C433643F28102A7700601205 /* BlueFalcon.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/iOS-Example/iOS-Example/Services/BluetoothService.swift
+++ b/examples/iOS-Example/iOS-Example/Services/BluetoothService.swift
@@ -107,7 +107,6 @@ class BluetoothService {
 }
 
 extension BluetoothService: BlueFalconDelegate {
-
     func didReadDescriptor(bluetoothPeripheral: BluetoothPeripheral, bluetoothCharacteristicDescriptor: CBDescriptor) {
         print("BT Service didReadDescriptor -> \(bluetoothCharacteristicDescriptor.value ?? "")")
     }
@@ -169,7 +168,10 @@ extension BluetoothService: BlueFalconDelegate {
             characteristicDelegateTuple.0 == bluetoothCharacteristicId ? characteristicDelegateTuple.1 : nil
         }
     }
-
+    
+    func didWriteCharacteristic(bluetoothPeripheral: BluetoothPeripheral, bluetoothCharacteristic: BluetoothCharacteristic, success: Bool) {
+        print("BT Service didWriteCharacteristic -> success: \(success)")
+    }
 }
 
 

--- a/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -343,6 +343,21 @@ actual class BlueFalcon actual constructor(
             }
         }
 
+        override fun onCharacteristicWrite(
+            gatt: BluetoothGatt?,
+            characteristic: BluetoothGattCharacteristic?,
+            status: Int
+        ) {
+            characteristic?.let { forcedCharacteristic ->
+                val characteristic = BluetoothCharacteristic(forcedCharacteristic)
+                gatt?.device?.let { bluetoothDevice ->
+                    delegates.forEach {
+                        it.didWriteCharacteristic(BluetoothPeripheral(bluetoothDevice), characteristic, status == BluetoothGatt.GATT_SUCCESS)
+                    }
+                }
+            }
+        }
+
         private fun handleCharacteristicValueChange(gatt: BluetoothGatt?, characteristic: BluetoothGattCharacteristic?) {
             characteristic?.let { forcedCharacteristic ->
                 val characteristic = BluetoothCharacteristic(forcedCharacteristic)

--- a/library/src/commonMain/kotlin/dev/bluefalcon/BlueFalconDelegate.kt
+++ b/library/src/commonMain/kotlin/dev/bluefalcon/BlueFalconDelegate.kt
@@ -29,4 +29,10 @@ interface BlueFalconDelegate {
         bluetoothPeripheral: BluetoothPeripheral,
         bluetoothCharacteristicDescriptor: BluetoothCharacteristicDescriptor
     )
+    @JsName("didWriteCharacteristic")
+    fun didWriteCharacteristic(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        success: Boolean
+    )
 }

--- a/library/src/iosMain/kotlin/dev/bluefalcon/PeripheralDelegate.kt
+++ b/library/src/iosMain/kotlin/dev/bluefalcon/PeripheralDelegate.kt
@@ -72,4 +72,22 @@ actual class PeripheralDelegate actual constructor(
     override fun peripheral(peripheral: CBPeripheral, didDiscoverDescriptorsForCharacteristic: CBCharacteristic, error: NSError?) {
         println("didDiscoverDescriptorsForCharacteristic")
     }
+
+    @Suppress("CONFLICTING_OVERLOADS")
+    override fun peripheral(peripheral: CBPeripheral, didWriteValueForCharacteristic: CBCharacteristic, error: NSError?) {
+        if (error != null) {
+            println("Error during characteristic write $error")
+        }
+
+        println("didUpdateValueForCharacteristic")
+        val device = BluetoothPeripheral(peripheral, rssiValue = null)
+        val characteristic = BluetoothCharacteristic(didWriteValueForCharacteristic)
+        blueFalcon.delegates.forEach {
+            it.didWriteCharacteristic(
+                device,
+                characteristic,
+                error != null
+            )
+        }
+    }
 }

--- a/library/src/macosX64Main/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/macosX64Main/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -293,6 +293,23 @@ actual class BlueFalcon actual constructor(
             println("didDiscoverDescriptorsForCharacteristic")
         }
 
+        @Suppress("CONFLICTING_OVERLOADS")
+        override fun peripheral(peripheral: CBPeripheral, didWriteValueForCharacteristic: CBCharacteristic, error: NSError?) {
+            if (error != null) {
+                println("Error during characteristic write $error")
+            }
+            println("didWriteValueForCharacteristic")
+
+            val device = BluetoothPeripheral(peripheral, rssiValue = null)
+            val characteristic = BluetoothCharacteristic(didWriteValueForCharacteristic)
+            delegates.forEach {
+                it.didWriteCharacteristic(
+                    device,
+                    characteristic,
+                    error == null
+                )
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Related to this issue https://github.com/Reedyuk/blue-falcon/issues/83, this PR introduces a new method which is called on a successful write.

This method is only called when a write with response is sent. The didCharacteristcValueChanged method cannot be used because it is only called when data is changed.

writeValue is called when a packet is successfully accepted. As an acknowledgment has been made. didCharacteristcValueChanged is called only when a value has changed.