### PR TITLE
Advertisement data

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ blueFalcon.scan()
 #### Install
 
 ```kotlin
-implementation 'dev.bluefalcon:blue-falcon-android:0.10.2'
+implementation 'dev.bluefalcon:blue-falcon-android:0.10.5'
 ```
 
 And if you are using the debug variant:
 
 ```kotlin
-implementation 'dev.bluefalcon:blue-falcon-android-debug:0.10.2'
+implementation 'dev.bluefalcon:blue-falcon-android-debug:0.10.5'
 ```
 
 The Android sdk requires an Application context, we do this by passing in on the BlueFalcon constructor, in this example we are calling the code from an activity(this).
@@ -57,7 +57,7 @@ try {
 The Raspberry Pi library is using Java.
 
 ```kotlin
-implementation 'dev.bluefalcon:blue-falcon-rpi:0.10.2'
+implementation 'dev.bluefalcon:blue-falcon-rpi:0.10.5'
 ```
 
 ### Javascript 
@@ -73,7 +73,7 @@ See the JS-Example for details on how to use.
 ### Install
 
 ```kotlin
-implementation 'dev.bluefalcon:blue-falcon:0.10.2'
+implementation 'dev.bluefalcon:blue-falcon:0.10.5'
 ```
 
 Please look at the Kotlin Multiplatform example in the Examples folder.

--- a/examples/Android-Example/build.gradle
+++ b/examples/Android-Example/build.gradle
@@ -61,14 +61,14 @@ dependencies {
     implementation 'dev.bluefalcon:blue-falcon-android-debug:0.10.5'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'com.google.android.material:material:1.3.0'
-    testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test:runner:1.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'com.google.android.material:material:1.5.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
 
     implementation "org.jetbrains.anko:anko:$anko_version"
     implementation "org.jetbrains.anko:anko-support-v4:$anko_version"

--- a/examples/Android-Example/build.gradle
+++ b/examples/Android-Example/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
-        classpath('com.android.tools.build:gradle:7.2.0-beta04')
+        classpath('com.android.tools.build:gradle:7.2.0-rc01')
     }
 
 }
@@ -34,11 +34,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 32
     defaultConfig {
         applicationId "dev.bluefalcon"
         minSdkVersion 24
-        targetSdkVersion 29
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -58,7 +58,7 @@ android {
 }
 
 dependencies {
-    implementation 'dev.bluefalcon:blue-falcon-android-debug:0.10.2'
+    implementation 'dev.bluefalcon:blue-falcon-android-debug:0.10.5'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/examples/Android-Example/gradle.properties
+++ b/examples/Android-Example/gradle.properties
@@ -16,4 +16,4 @@ version=0.10.2
 group=dev.bluefalcon
 libraryName=blue-falcon
 
-kotlin_version=1.6.20
+kotlin_version=1.6.21

--- a/examples/Android-Example/src/main/AndroidManifest.xml
+++ b/examples/Android-Example/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
             android:name=".BlueFalconApplication"

--- a/examples/Android-Example/src/main/AndroidManifest.xml
+++ b/examples/Android-Example/src/main/AndroidManifest.xml
@@ -1,23 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="dev.bluefalcon">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="dev.bluefalcon">
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADVERTISE"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_CONNECT"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
+
     <application
-            android:name=".BlueFalconApplication"
-            android:allowBackup="true"
-            android:icon="@mipmap/ic_launcher"
-            android:label="@string/app_name"
-            android:roundIcon="@mipmap/ic_launcher_round"
-            android:supportsRtl="true"
-            android:theme="@style/AppTheme">
-        <activity android:name=".activities.DevicesActivity">
+        android:name=".BlueFalconApplication"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity android:name=".activities.DevicesActivity"
+            android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <activity android:name=".activities.DeviceActivity" />

--- a/examples/Android-Example/src/main/java/dev/bluefalcon/activities/DeviceActivity.kt
+++ b/examples/Android-Example/src/main/java/dev/bluefalcon/activities/DeviceActivity.kt
@@ -13,10 +13,11 @@ class DeviceActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         deviceViewModel = DeviceViewModel(
             this,
             BluetoothPeripheral(
-                intent.getParcelableExtra("device") as BluetoothDevice
+                intent.getParcelableExtra("device")!!
             )
         )
         deviceViewModel.deviceActivityUI.setContentView(this)

--- a/examples/Android-Example/src/main/java/dev/bluefalcon/activities/DeviceServiceActivity.kt
+++ b/examples/Android-Example/src/main/java/dev/bluefalcon/activities/DeviceServiceActivity.kt
@@ -17,9 +17,9 @@ class DeviceServiceActivity : AppCompatActivity() {
         deviceServiceViewModel = DeviceServiceViewModel(
             this,
             BluetoothPeripheral(
-                intent.getParcelableExtra("device") as BluetoothDevice
+                intent.getParcelableExtra("device")!!
             ),
-            intent.getParcelableExtra("service") as BluetoothGattService
+            intent.getParcelableExtra("service")!!
         )
         deviceServiceViewModel.deviceServiceActivityUI.setContentView(this)
     }

--- a/examples/Android-Example/src/main/java/dev/bluefalcon/services/BluetoothService.kt
+++ b/examples/Android-Example/src/main/java/dev/bluefalcon/services/BluetoothService.kt
@@ -1,5 +1,6 @@
 package dev.bluefalcon.services
 
+import AdvertisementDataRetrievalKeys
 import android.bluetooth.BluetoothGattCharacteristic
 import dev.bluefalcon.*
 import java.util.*
@@ -65,10 +66,15 @@ class BluetoothService: BlueFalconDelegate {
         blueFalcon.readDescriptor(bluetoothPeripheral, bluetoothCharacteristic, bluetoothCharacteristicDescriptor)
     }
 
-    override fun didDiscoverDevice(bluetoothPeripheral: BluetoothPeripheral) {
+    override fun didDiscoverDevice(
+        bluetoothPeripheral: BluetoothPeripheral,
+        advertisementData: Map<AdvertisementDataRetrievalKeys, Any>
+    ) {
         if (devices.firstOrNull {
             it.bluetoothDevice.address == bluetoothPeripheral.bluetoothDevice.address
         } == null) {
+            println("Device advertised data: $advertisementData")
+
             devices.add(bluetoothPeripheral)
             detectedDeviceDelegates.forEach { delegate ->
                 delegate.discoveredDevice(devices)

--- a/examples/Android-Example/src/main/java/dev/bluefalcon/viewModels/DevicesViewModel.kt
+++ b/examples/Android-Example/src/main/java/dev/bluefalcon/viewModels/DevicesViewModel.kt
@@ -31,7 +31,7 @@ class DevicesViewModel(private val devicesActivity: DevicesActivity): BluetoothS
     }
 
     private fun requestLocationPermission() {
-        val permission = arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
+        val permission = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
         ActivityCompat.requestPermissions(devicesActivity, permission, 0)
     }
 

--- a/examples/JS-Example/index.html
+++ b/examples/JS-Example/index.html
@@ -14,8 +14,8 @@
       var characteristics = new Array();
        const blueFalcon = new this['blue-falcon'].dev.bluefalcon.BlueFalcon();
        var Delegate = {
-         didDiscoverDevice: function(bluetoothPeripheral) {
-            console.log(`didDiscover ${bluetoothPeripheral.name}`);
+         didDiscoverDevice: function(bluetoothPeripheral, advertisementData) {
+            console.log(`didDiscover ${bluetoothPeripheral.name} with data: ${advertisementData}`);
             blueFalcon.connect(bluetoothPeripheral);
          },
          didConnect: function(bluetoothPeripheral) {

--- a/examples/MacOS-Example/MacOS-Example/Services/BluetoothService.swift
+++ b/examples/MacOS-Example/MacOS-Example/Services/BluetoothService.swift
@@ -115,10 +115,12 @@ extension BluetoothService: BlueFalconDelegate {
     func didRssiUpdate(bluetoothPeripheral: BluetoothPeripheral) {
     }
 
-    func didDiscoverDevice(bluetoothPeripheral: BluetoothPeripheral) {
+    func didDiscoverDevice(bluetoothPeripheral: BluetoothPeripheral, advertisementData: [AdvertisementDataRetrievalKeys : Any]) {
         guard (devices.first {
             $0.bluetoothDevice.identifier == bluetoothPeripheral.bluetoothDevice.identifier
         } == nil) else { return }
+        print("Device advertised data: \(advertisementData)")
+        
         devices.append(bluetoothPeripheral)
         detectedDeviceDelegates.forEach { delegate in
             delegate.discoveredDevice(devices: devices)

--- a/examples/RPI-Example/src/main/kotlin/dev/bluefalcon/controller/MainController.kt
+++ b/examples/RPI-Example/src/main/kotlin/dev/bluefalcon/controller/MainController.kt
@@ -44,7 +44,7 @@ class MainController: Controller(), BlueFalconDelegate {
         }
     }
 
-    override fun didDiscoverDevice(bluetoothPeripheral: BluetoothPeripheral) {
+    override fun didDiscoverDevice(bluetoothPeripheral: BluetoothPeripheral, advertisementData: [AdvertisementDataRetrievalKeys : Any]) {
         println("didDiscoverDevice ${bluetoothPeripheral.name}")
         devices.add(bluetoothPeripheral)
         blueFalcon.connect(bluetoothPeripheral)

--- a/examples/iOS-Example/iOS-Example/Services/BluetoothService.swift
+++ b/examples/iOS-Example/iOS-Example/Services/BluetoothService.swift
@@ -114,10 +114,14 @@ extension BluetoothService: BlueFalconDelegate {
     func didRssiUpdate(bluetoothPeripheral: BluetoothPeripheral) {
     }
 
-    func didDiscoverDevice(bluetoothPeripheral: BluetoothPeripheral) {
+    func didDiscoverDevice(bluetoothPeripheral: BluetoothPeripheral, advertisementData: [AdvertisementDataRetrievalKeys : Any]) {
         guard (devices.first {
             $0.bluetoothDevice.identifier == bluetoothPeripheral.bluetoothDevice.identifier
         } == nil) else { return }
+        
+        print("Device advertised data: \(advertisementData)")
+        
+        
         devices.append(bluetoothPeripheral)
         detectedDeviceDelegates.forEach { delegate in
             delegate.discoveredDevice(devices: devices)

--- a/library/Blue_Falcon.podspec
+++ b/library/Blue_Falcon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'Blue_Falcon'
-    spec.version                  = '0.9.1'
+    spec.version                  = '0.10.5'
     spec.homepage                 = 'http://www.bluefalcon.dev'
     spec.source                   = { :git => "Not Published", :tag => "Cocoapods/#{spec.name}/#{spec.version}" }
     spec.authors                  = ''

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -40,11 +40,11 @@ val developerEmail: String by project
 val group: String by project
 
 android {
-    compileSdk = 32
+    compileSdk = 26
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdk = 24
-        targetSdk = 32
+        targetSdk = 26
     }
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -2,7 +2,7 @@ import java.util.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
-    kotlin("multiplatform") version "1.6.20"
+    kotlin("multiplatform") version "1.6.21"
     id("com.android.library")
     id("maven-publish")
     id("signing")
@@ -40,11 +40,11 @@ val developerEmail: String by project
 val group: String by project
 
 android {
-    compileSdk = 29
+    compileSdk = 32
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdk = 24
-        targetSdk = 29
+        targetSdk = 32
     }
 }
 

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.configureondemand = false
 android.useAndroidX=true
 android.enableJetifier=true
 
-version=0.10.4
+version=0.10.5
 group=dev.bluefalcon
 libraryName=blue-falcon
 

--- a/library/src/androidMain/AndroidManifest.xml
+++ b/library/src/androidMain/AndroidManifest.xml
@@ -1,7 +1,9 @@
-<manifest
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        package="dev.bluefalcon.blueFalcon">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="dev.bluefalcon.blueFalcon">
+
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 </manifest>

--- a/library/src/commonMain/kotlin/dev/bluefalcon/AdvertisementDataRetrievalKeys.kt
+++ b/library/src/commonMain/kotlin/dev/bluefalcon/AdvertisementDataRetrievalKeys.kt
@@ -1,0 +1,6 @@
+enum class AdvertisementDataRetrievalKeys {
+    LocalName,
+    ManufacturerData,
+    ServiceUUIDsKey,
+    IsConnectable,
+}

--- a/library/src/commonMain/kotlin/dev/bluefalcon/BlueFalconDelegate.kt
+++ b/library/src/commonMain/kotlin/dev/bluefalcon/BlueFalconDelegate.kt
@@ -1,12 +1,13 @@
 package dev.bluefalcon
 
+import AdvertisementDataRetrievalKeys
 import kotlin.js.JsName
 
 @JsName("BlueFalconDelegate")
 interface BlueFalconDelegate {
 
     @JsName("didDiscoverDevice")
-    fun didDiscoverDevice(bluetoothPeripheral: BluetoothPeripheral)
+    fun didDiscoverDevice(bluetoothPeripheral: BluetoothPeripheral, advertisementData: Map<AdvertisementDataRetrievalKeys, Any>)
     @JsName("didConnect")
     fun didConnect(bluetoothPeripheral: BluetoothPeripheral)
     @JsName("didDisconnect")

--- a/library/src/iosMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/iosMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -48,9 +48,9 @@ actual class BlueFalcon actual constructor(
             CBManagerStatePoweredOn -> {
                 if (serviceUUID != null) {
                     val serviceCBUUID = CBUUID.UUIDWithString(serviceUUID)
-                    centralManager.scanForPeripheralsWithServices(listOf(serviceCBUUID), null)
+                    centralManager.scanForPeripheralsWithServices(listOf(serviceCBUUID), mapOf(CBCentralManagerScanOptionAllowDuplicatesKey to true) )
                 } else {
-                    centralManager.scanForPeripheralsWithServices(null, null)
+                    centralManager.scanForPeripheralsWithServices(null, mapOf(CBCentralManagerScanOptionAllowDuplicatesKey to true) )
                 }
             }
         }

--- a/library/src/jsMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/jsMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -53,7 +53,7 @@ actual class BlueFalcon actual constructor(context: ApplicationContext, serviceU
             .then { bluetoothDevice ->
                 val device = BluetoothPeripheral(bluetoothDevice)
                 delegates.forEach {
-                    it.didDiscoverDevice(device)
+                    it.didDiscoverDevice(device, mapOf()) //TODO
                 }
             }
     }

--- a/library/src/rpiMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/rpiMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -1,9 +1,7 @@
 package dev.bluefalcon
 
 import AdvertisementDataRetrievalKeys
-import android.bluetooth.le.ScanRecord
 import com.welie.blessed.*
-import java.nio.ByteBuffer
 import java.util.*
 
 actual class BlueFalcon actual constructor(context: ApplicationContext, private val serviceUUID: String?) {


### PR DESCRIPTION
It was added that the advertist data from the device is also passed.

So that the code can also be used in the shared module, the advertist data is mapped to a common format. This makes them usable everywhere in the same way.

Furthermore, the dependencies for Android were updated and all examples are adapted

@Reedyuk Version number is already increased.