### PR TITLE
:bug: Fix that manufacture data was from type NSData instead of byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ blueFalcon.scan()
 #### Install
 
 ```kotlin
-implementation 'dev.bluefalcon:blue-falcon-android:0.10.5'
+implementation 'dev.bluefalcon:blue-falcon-android:0.10.6'
 ```
 
 And if you are using the debug variant:
 
 ```kotlin
-implementation 'dev.bluefalcon:blue-falcon-android-debug:0.10.5'
+implementation 'dev.bluefalcon:blue-falcon-android-debug:0.10.6'
 ```
 
 The Android sdk requires an Application context, we do this by passing in on the BlueFalcon constructor, in this example we are calling the code from an activity(this).
@@ -57,7 +57,7 @@ try {
 The Raspberry Pi library is using Java.
 
 ```kotlin
-implementation 'dev.bluefalcon:blue-falcon-rpi:0.10.5'
+implementation 'dev.bluefalcon:blue-falcon-rpi:0.10.6'
 ```
 
 ### Javascript 
@@ -73,7 +73,7 @@ See the JS-Example for details on how to use.
 ### Install
 
 ```kotlin
-implementation 'dev.bluefalcon:blue-falcon:0.10.5'
+implementation 'dev.bluefalcon:blue-falcon:0.10.6'
 ```
 
 Please look at the Kotlin Multiplatform example in the Examples folder.

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.configureondemand = false
 android.useAndroidX=true
 android.enableJetifier=true
 
-version=0.10.5
+version=0.10.6
 group=dev.bluefalcon
 libraryName=blue-falcon
 

--- a/library/src/iosMain/kotlin/dev/bluefalcon/BluetoothPeripheralManager.kt
+++ b/library/src/iosMain/kotlin/dev/bluefalcon/BluetoothPeripheralManager.kt
@@ -2,8 +2,8 @@ package dev.bluefalcon
 
 import AdvertisementDataRetrievalKeys
 import platform.CoreBluetooth.*
+import platform.Foundation.NSData
 import platform.Foundation.NSError
-import platform.Foundation.NSMutableArray
 import platform.Foundation.NSNumber
 import platform.darwin.NSObject
 
@@ -96,6 +96,10 @@ actual class BluetoothPeripheralManager actual constructor(
                     kotlinUUIDStrings.add(kotlinUUIDString)
                 }
                 sharedAdvertisementData[mappedKey] = kotlinUUIDStrings
+            } else if (mappedKey == AdvertisementDataRetrievalKeys.ManufacturerData) {
+                val data = value as NSData
+
+                sharedAdvertisementData[mappedKey] = data.toByteArray()
             } else {
                 sharedAdvertisementData[mappedKey] = value
             }

--- a/library/src/iosMain/kotlin/dev/bluefalcon/NSData.kt
+++ b/library/src/iosMain/kotlin/dev/bluefalcon/NSData.kt
@@ -1,13 +1,22 @@
 package dev.bluefalcon
 
-import kotlinx.cinterop.allocArrayOf
-import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.*
 import platform.Foundation.*
-import kotlinx.cinterop.allocArrayOf
-import kotlinx.cinterop.memScoped
+import platform.posix.memcpy
 
 fun NSData.string(): String? {
     return NSString.create(this, NSUTF8StringEncoding) as String?
+}
+
+
+fun NSData.toByteArray(): ByteArray {
+    val data = this
+    val d = memScoped { data }
+    return ByteArray(d.length.toInt()).apply {
+        usePinned {
+            memcpy(it.addressOf(0), d.bytes, d.length)
+        }
+    }
 }
 
 fun ByteArray.toData(): NSData = memScoped {

--- a/library/src/macosX64Main/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/macosX64Main/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -371,6 +371,10 @@ actual class BlueFalcon actual constructor(
                     kotlinUUIDStrings.add(kotlinUUIDString)
                 }
                 sharedAdvertisementData[mappedKey] = kotlinUUIDStrings
+            } else if (mappedKey == AdvertisementDataRetrievalKeys.ManufacturerData) {
+                val data = value as NSData
+
+                sharedAdvertisementData[mappedKey] = data.toByteArray()
             } else {
                 sharedAdvertisementData[mappedKey] = value
             }

--- a/library/src/macosX64Main/kotlin/dev/bluefalcon/NSData.kt
+++ b/library/src/macosX64Main/kotlin/dev/bluefalcon/NSData.kt
@@ -1,13 +1,21 @@
 package dev.bluefalcon
 
-import kotlinx.cinterop.allocArrayOf
-import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.*
 import platform.Foundation.*
-import kotlinx.cinterop.allocArrayOf
-import kotlinx.cinterop.memScoped
+import platform.posix.memcpy
 
 fun NSData.string(): String? {
     return NSString.create(this, NSUTF8StringEncoding) as String?
+}
+
+fun NSData.toByteArray(): ByteArray {
+    val data = this
+    val d = memScoped { data }
+    return ByteArray(d.length.toInt()).apply {
+        usePinned {
+            memcpy(it.addressOf(0), d.bytes, d.length)
+        }
+    }
 }
 
 fun ByteArray.toData(): NSData = memScoped {


### PR DESCRIPTION
Fixed a bug where the Manufacture Data in the shared code could not be used when running the project on iOS/Mac OS. 

This was because the data was of type NSData and not ByteArray. A conversion is necessary. 
@Reedyuk 