### PR TITLE
Update build.gradle.kts

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -74,6 +74,12 @@ kotlin {
             xcf.add(this)
         }
     }
+    iosX64 {
+        binaries.framework {
+            baseName = frameworkName
+            xcf.add(this)
+        }
+    }
     iosArm64("ios") {
         binaries.framework {
             baseName = frameworkName
@@ -108,6 +114,8 @@ kotlin {
         val iosMain by getting
         val iosSimulatorArm64Main by getting
         iosSimulatorArm64Main.dependsOn(iosMain)
+        val iosX64Main by getting
+        iosX64Main.dependsOn(iosMain)
         val macosX64Main by getting
     }
 }


### PR DESCRIPTION
simulator X86_64 added to existing simulator Arm64
This is required for testing on old machines with Intel chips (althougt Bluetooth is not supported at simulator at all, the testing in simulator sometime usefull)