### PR TITLE
onDescriptorWrite handling is required for BluetoothGattCallback

### DIFF
--- a/examples/Android-Example/build.gradle
+++ b/examples/Android-Example/build.gradle
@@ -28,7 +28,6 @@ repositories {
     google()
 }
 
-
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'

--- a/examples/Android-Example/src/main/java/dev/bluefalcon/services/BluetoothService.kt
+++ b/examples/Android-Example/src/main/java/dev/bluefalcon/services/BluetoothService.kt
@@ -66,15 +66,6 @@ class BluetoothService: BlueFalconDelegate {
         blueFalcon.readDescriptor(bluetoothPeripheral, bluetoothCharacteristic, bluetoothCharacteristicDescriptor)
     }
 
-//    fun writeDescriptor(
-//        bluetoothPeripheral: BluetoothPeripheral,
-//        bluetoothCharacteristic: BluetoothCharacteristic,
-//        bluetoothCharacteristicDescriptor: BluetoothCharacteristicDescriptor
-//    ) {
-//        log("btservice writeDescriptor")
-//        blueFalcon.writeDescriptor(bluetoothPeripheral, bluetoothCharacteristic, bluetoothCharacteristicDescriptor)
-//    }
-
     override fun didDiscoverDevice(
         bluetoothPeripheral: BluetoothPeripheral,
         advertisementData: Map<AdvertisementDataRetrievalKeys, Any>

--- a/examples/Android-Example/src/main/java/dev/bluefalcon/services/BluetoothService.kt
+++ b/examples/Android-Example/src/main/java/dev/bluefalcon/services/BluetoothService.kt
@@ -66,6 +66,15 @@ class BluetoothService: BlueFalconDelegate {
         blueFalcon.readDescriptor(bluetoothPeripheral, bluetoothCharacteristic, bluetoothCharacteristicDescriptor)
     }
 
+//    fun writeDescriptor(
+//        bluetoothPeripheral: BluetoothPeripheral,
+//        bluetoothCharacteristic: BluetoothCharacteristic,
+//        bluetoothCharacteristicDescriptor: BluetoothCharacteristicDescriptor
+//    ) {
+//        log("btservice writeDescriptor")
+//        blueFalcon.writeDescriptor(bluetoothPeripheral, bluetoothCharacteristic, bluetoothCharacteristicDescriptor)
+//    }
+
     override fun didDiscoverDevice(
         bluetoothPeripheral: BluetoothPeripheral,
         advertisementData: Map<AdvertisementDataRetrievalKeys, Any>

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -74,6 +74,12 @@ kotlin {
             xcf.add(this)
         }
     }
+    iosX64 {
+        binaries.framework {
+            baseName = frameworkName
+            xcf.add(this)
+        }
+    }
     iosArm64("ios") {
         binaries.framework {
             baseName = frameworkName
@@ -108,6 +114,8 @@ kotlin {
         val iosMain by getting
         val iosSimulatorArm64Main by getting
         iosSimulatorArm64Main.dependsOn(iosMain)
+        val iosX64Main by getting
+        iosX64Main.dependsOn(iosMain)
         val macosX64Main by getting
     }
 }

--- a/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -378,6 +378,25 @@ actual class BlueFalcon actual constructor(
             }
         }
 
+        override fun onDescriptorWrite(
+            gatt: BluetoothGatt?,
+            descriptor: BluetoothGattDescriptor?,
+            status: Int
+        ) {
+            log("onDescriptorWrite $descriptor")
+            descriptor?.let { forcedDescriptor ->
+                gatt?.device?.let { bluetoothDevice ->
+                    log("onDescriptorWrite value ${forcedDescriptor.value}")
+                    delegates.forEach {
+                        it.didWriteDescriptor(
+                            BluetoothPeripheral(bluetoothDevice),
+                            forcedDescriptor
+                        )
+                    }
+                }
+            }
+        }
+
         override fun onCharacteristicWrite(
             gatt: BluetoothGatt?,
             characteristic: BluetoothGattCharacteristic?,

--- a/library/src/commonMain/kotlin/dev/bluefalcon/BlueFalconDelegate.kt
+++ b/library/src/commonMain/kotlin/dev/bluefalcon/BlueFalconDelegate.kt
@@ -30,6 +30,11 @@ interface BlueFalconDelegate {
         bluetoothPeripheral: BluetoothPeripheral,
         bluetoothCharacteristicDescriptor: BluetoothCharacteristicDescriptor
     )
+    @JsName("didWriteDescriptor")
+    fun didWriteDescriptor(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristicDescriptor: BluetoothCharacteristicDescriptor
+    )
     @JsName("didWriteCharacteristic")
     fun didWriteCharacteristic(
         bluetoothPeripheral: BluetoothPeripheral,


### PR DESCRIPTION
didWriteDescriptor handler has added into BlueFalconDelegate. It is called from onDescriptorWrite for BluetoothGattCallback function. The handling is required to properly work with such device as Bosch GLM50C Bluetooth range-finder e.g.