### PR TITLE
add jitpack to install require

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ See the JS-Example for details on how to use.
 
 ```kotlin
 implementation 'dev.bluefalcon:blue-falcon:0.10.10'
+
+repositories {
+    maven { url = uri("https://jitpack.io") }
+    // or if you use KTS
+    maven("https://jitpack.io")
+}
+
 ```
 
 Please look at the Kotlin Multiplatform example in the Examples folder.


### PR DESCRIPTION
Because the library is based on `com.github.weliem:blessed-bluez`, you will have to specify jitpack.io

Before:
<img width="1479" alt="image" src="https://github.com/Reedyuk/blue-falcon/assets/53047160/48f2f53f-fe33-458f-8712-f0146f103a6f">

After:
<img width="634" alt="image" src="https://github.com/Reedyuk/blue-falcon/assets/53047160/036bd3ff-af4c-43ed-80cf-7426e6127a51">
