### PR TITLE
Advertisement data is not being parsed correctly on Android

### DIFF
--- a/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -515,7 +515,6 @@ actual class BlueFalcon actual constructor(
                     sharedAdvertisementData[AdvertisementDataRetrievalKeys.ServiceUUIDsKey] =
                         uuidAsStringList
                 }
-                else -> continue
             }
 
             index += length


### PR DESCRIPTION
The `continue` statement when the field type is not handled results in skipping `index += length`. Subsequent fields will not be parsed correctly.