### PR TITLE
Keep reference to PeripheralDelegate on iOS to prevent deallocation. Probably fixes #99 as well.

### DIFF
--- a/library/src/iosMain/kotlin/dev/bluefalcon/BluetoothPeripheralManager.kt
+++ b/library/src/iosMain/kotlin/dev/bluefalcon/BluetoothPeripheralManager.kt
@@ -10,6 +10,7 @@ import platform.darwin.NSObject
 actual class BluetoothPeripheralManager actual constructor(
     private val blueFalcon: BlueFalcon
 ) : NSObject(), CBCentralManagerDelegateProtocol {
+    private val delegate = PeripheralDelegate(blueFalcon)
 
     override fun centralManagerDidUpdateState(central: CBCentralManager) {
         when (central.state) {
@@ -50,7 +51,7 @@ actual class BluetoothPeripheralManager actual constructor(
         blueFalcon.delegates.forEach {
             it.didConnect(device)
         }
-        didConnectPeripheral.delegate = PeripheralDelegate(blueFalcon)
+        didConnectPeripheral.delegate = delegate
         didConnectPeripheral.discoverServices(null)
     }
 


### PR DESCRIPTION
Keep reference to PeripheralDelegate on iOS (similar to how it's already implemented in this library for MacOS), because CBPeripheral's weak reference does not prevent deallocation/GC. Probably also fixes #99