### PR TITLE
peripherals set now have only one entry per uuid

### DIFF
--- a/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -259,7 +259,7 @@ actual class BlueFalcon actual constructor(private val context: ApplicationConte
                     val bluetoothPeripheral = BluetoothPeripheral(device)
                     bluetoothPeripheral.rssi = scanResult.rssi.toFloat()
 
-                    _peripherals.tryEmit(_peripherals.value + setOf(bluetoothPeripheral))
+                    _peripherals.tryEmit(_peripherals.value.filter{ it.uuid != bluetoothPeripheral.uuid }.toSet() + setOf(bluetoothPeripheral))
                     delegates.forEach {
                         it.didDiscoverDevice(bluetoothPeripheral, sharedAdvertisementData)
                     }

--- a/library/src/appleMain/kotlin/dev/bluefalcon/BluetoothPeripheralManager.kt
+++ b/library/src/appleMain/kotlin/dev/bluefalcon/BluetoothPeripheralManager.kt
@@ -35,7 +35,7 @@ class BluetoothPeripheralManager constructor(
             val device = BluetoothPeripheral(didDiscoverPeripheral, rssiValue = RSSI.floatValue)
 
             val sharedAdvertisementData = mapNativeAdvertisementDataToShared(advertisementData)
-            blueFalcon._peripherals.tryEmit(blueFalcon._peripherals.value + setOf(device))
+            blueFalcon._peripherals.tryEmit(blueFalcon._peripherals.value.filter{ it.uuid != device.uuid }.toSet() + setOf(device))
             blueFalcon.delegates.forEach {
                 it.didDiscoverDevice(
                     bluetoothPeripheral = device,

--- a/library/src/rpiMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/rpiMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -20,7 +20,7 @@ actual class BlueFalcon actual constructor(context: ApplicationContext) {
             val device = BluetoothPeripheral(peripheral)
 
             val sharedAdvertisementData = mapNativeAdvertisementDataToShared(scanResult = scanResult, isConnectable = true)
-            _peripherals.tryEmit(_peripherals.value + setOf(device))
+            _peripherals.tryEmit(_peripherals.value.filter{ it.uuid != device.uuid }.toSet() + setOf(device))
             delegates.forEach { it.didDiscoverDevice(device, sharedAdvertisementData) }
         }
     }


### PR DESCRIPTION
Collecting peripherals used to accumulate newly received advertisements, resulting in a costantly growing set. My modification filters the old set before adding new devices, so if a device already exists in the set it is filtered out and then re-appended.
This behaviour is necessary to update the rssi field into BluetoothPeripheral object, while avoiding duplicate entries with same UUID.