### PR TITLE
Added mtuSize variable for BluetoothPeripheral

### DIFF
--- a/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -333,8 +333,10 @@ actual class BlueFalcon actual constructor(
                 return
             }
             gatt?.device?.let { bluetoothDevice ->
+                val bluetoothPeripheral = BluetoothPeripheral(bluetoothDevice)
+                bluetoothPeripheral.mtuSize = mtu
                 delegates.forEach {
-                    it.didUpdateMTU(BluetoothPeripheral(bluetoothDevice))
+                    it.didUpdateMTU(bluetoothPeripheral)
                 }
             }
         }

--- a/library/src/androidMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -14,6 +14,7 @@ actual class BluetoothPeripheral(val bluetoothDevice: BluetoothDevice) : Parcela
         get() = bluetoothDevice.address
 
     actual var rssi: Float? = null
+    actual var mtuSize: Int? = null
 
     internal actual val _servicesFlow = MutableStateFlow<List<BluetoothService>>(emptyList())
 

--- a/library/src/appleMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/appleMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -180,7 +180,7 @@ actual class BlueFalcon actual constructor(
     }
 
     actual fun changeMTU(bluetoothPeripheral: BluetoothPeripheral, mtuSize: Int) {
-        val mtuSize = bluetoothPeripheral.maximumWriteValueLength(for: .withResponse)
+        val mtuSize = bluetoothPeripheral.bluetoothDevice.maximumWriteValueLength(for: .withResponse)
         log.debug("Change MTU size called but not needed: ${mtuSize}")
         val btPeripheral = bluetoothPeripheral
         btPeripheral.mtuSize = mtuSize

--- a/library/src/appleMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/appleMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -180,7 +180,7 @@ actual class BlueFalcon actual constructor(
     }
 
     actual fun changeMTU(bluetoothPeripheral: BluetoothPeripheral, mtuSize: Int) {
-        val mtuSize = centralManager.maximumWriteValueLength(for: .withResponse)
+        val mtuSize = bluetoothPeripheral.maximumWriteValueLength(for: .withResponse)
         log.debug("Change MTU size called but not needed: ${mtuSize}")
         val btPeripheral = bluetoothPeripheral
         btPeripheral.mtuSize = mtuSize
@@ -188,5 +188,4 @@ actual class BlueFalcon actual constructor(
             it.didUpdateMTU(btPeripheral)
         }
     }
-
 }

--- a/library/src/appleMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/appleMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -183,7 +183,7 @@ actual class BlueFalcon actual constructor(
         var mtu = bluetoothPeripheral.bluetoothDevice.maximumWriteValueLengthForType(CBCharacteristicWriteWithResponse)
         log.debug("Change MTU size called but not needed: ${mtuSize}")
         val btPeripheral = bluetoothPeripheral
-        btPeripheral.mtuSize = mtu
+        btPeripheral.mtuSize = mtu.toInt()
         delegates.forEach {
             it.didUpdateMTU(btPeripheral)
         }

--- a/library/src/appleMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/appleMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -180,10 +180,10 @@ actual class BlueFalcon actual constructor(
     }
 
     actual fun changeMTU(bluetoothPeripheral: BluetoothPeripheral, mtuSize: Int) {
-        val mtuSize = bluetoothPeripheral.bluetoothDevice.maximumWriteValueLength(for: .withResponse)
+        var mtu = bluetoothPeripheral.bluetoothDevice.maximumWriteValueLengthForType(CBCharacteristicWriteWithResponse)
         log.debug("Change MTU size called but not needed: ${mtuSize}")
         val btPeripheral = bluetoothPeripheral
-        btPeripheral.mtuSize = mtuSize
+        btPeripheral.mtuSize = mtu
         delegates.forEach {
             it.didUpdateMTU(btPeripheral)
         }

--- a/library/src/appleMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/appleMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -180,9 +180,12 @@ actual class BlueFalcon actual constructor(
     }
 
     actual fun changeMTU(bluetoothPeripheral: BluetoothPeripheral, mtuSize: Int) {
-        log.debug("Change MTU size called but not needed.")
+        val mtuSize = centralManager.maximumWriteValueLength(for: .withResponse)
+        log.debug("Change MTU size called but not needed: ${mtuSize}")
+        val btPeripheral = bluetoothPeripheral
+        btPeripheral.mtuSize = mtuSize
         delegates.forEach {
-            it.didUpdateMTU(bluetoothPeripheral)
+            it.didUpdateMTU(btPeripheral)
         }
     }
 

--- a/library/src/appleMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/appleMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -7,6 +7,7 @@ import platform.CoreBluetooth.CBService
 actual class BluetoothPeripheral(val bluetoothDevice: CBPeripheral, val rssiValue: Float?) {
     actual val name: String? = bluetoothDevice.name
     actual var rssi: Float? = rssiValue
+    actual var mtuSize: Int? = null
     actual val services: List<BluetoothService>
         get() = bluetoothDevice.services?.map {
             BluetoothService(it as CBService)

--- a/library/src/commonMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/commonMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -6,6 +6,7 @@ expect class BluetoothPeripheral {
     val name: String?
     val uuid: String
     var rssi: Float?
+    var mtuSize: Int?
     val services: List<BluetoothService>
     internal val _servicesFlow: MutableStateFlow<List<BluetoothService>>
 }

--- a/library/src/jsMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/jsMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -14,6 +14,10 @@ actual class BluetoothPeripheral(val device: BluetoothDevice) {
         get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
         set(value) {}
 
+    actual var mtuSize: Int?
+        get() = TODO("not implemented")
+        set(value) {}
+
     internal actual val _servicesFlow = MutableStateFlow<List<BluetoothService>>(emptyList())
     val serviceArray: Array<BluetoothService> get() = services.toTypedArray()
 }

--- a/library/src/rpiMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/rpiMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -12,6 +12,7 @@ actual class BluetoothPeripheral(val bluetoothDevice: BluetoothPeripheral) {
         get() = bluetoothDevice.address
 
     actual var rssi: Float? = null
+    actual var mtuSize: Int? = null
 
     internal actual val _servicesFlow = MutableStateFlow<List<BluetoothService>>(emptyList())
 }


### PR DESCRIPTION
After the changeMTU call, mtuSize is returned as a string but not stored in BluetoothPeripheral. This change allows the user to access the negotiated mtuSize in the BluetoothPeripheral class.

EDIT: After a lot of internet sleuthing, the function name for the CoreBluetooth CBPeripheral library turned out to be `maximumWriteValueLengthForType`: https://forums.developer.apple.com/forums/thread/73871. Also updated for int conversion.