### PR TITLE
Be more defensive about assigning advertised values that may be empty

### DIFF
--- a/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -549,14 +549,23 @@ actual class BlueFalcon actual constructor(
             if (isConnectable) 1 else 0
 
         if (Build.VERSION.SDK_INT >= 33) {
-            sharedAdvertisementData[AdvertisementDataRetrievalKeys.LocalName] =
-                scanRecord.deviceName as Any
-            sharedAdvertisementData[AdvertisementDataRetrievalKeys.ManufacturerData] =
-                scanRecord.manufacturerSpecificData
+
+            if (scanRecord.deviceName != null) {
+                sharedAdvertisementData[AdvertisementDataRetrievalKeys.LocalName] =
+                    scanRecord.deviceName as Any
+            }
+
+            if (scanRecord.manufacturerSpecificData != null) {
+                sharedAdvertisementData[AdvertisementDataRetrievalKeys.ManufacturerData] =
+                    scanRecord.manufacturerSpecificData
+            }
 
             // Map from ParcelUuid to Strings
-            sharedAdvertisementData[AdvertisementDataRetrievalKeys.ServiceUUIDsKey] =
-                scanRecord.serviceUuids.map { it.toString() }
+            if (scanRecord.serviceUuids != null) {
+                sharedAdvertisementData[AdvertisementDataRetrievalKeys.ServiceUUIDsKey] =
+                    scanRecord.serviceUuids.map { it.toString() }
+            }
+
         } else {
             val advertisementBytes = scanRecord.bytes
             var index = 0


### PR DESCRIPTION
**Problem**

When encountering empty values for advertised names or manufacturer data, the attempted coercion from `null` to `Any` fails at runtime, this bug was introduced in #165 when support for the platform getters/property accessors was added

**Solution**
Added defensive guards to check for null values before attempting to assign the values to the map

**Testing**
I did figure out testing this time, since I introduced this bug in #165 having been unable to test at that time

I updated the version in `./library/gradle.properties` from `2.2.7` to `2.2.8-pre` and built the library locally with `./Library/gradlew -p ./Library build`, then I pushed it to my local maven repository with `./Library/gradlew -p ./Library publishToMavenLocal` and consumed that version in my app, confirming it now works as expected (listing services during discovery, and not raising any exceptions)
