### PR TITLE
Added a fix for darwin users, if you pass in a perihperal from anothe…

### DIFF
--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.configureondemand = false
 android.useAndroidX=true
 android.enableJetifier=true
 
-version=2.2.8
+version=2.2.9
 group=dev.bluefalcon
 libraryName=blue-falcon
 kotlinx_coroutines_version=1.9.0


### PR DESCRIPTION
…r instance of a cbcentral manager, then previously it would miss the callbacks. This fixes this issue by re-associating cbmanager with it.