### PR TITLE
Connection priority enum + refactor of android code

### DIFF
--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.configureondemand = false
 android.useAndroidX=true
 android.enableJetifier=true
 
-version=2.2.9
+version=2.2.10
 group=dev.bluefalcon
 libraryName=blue-falcon
 kotlinx_coroutines_version=1.9.0

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.configureondemand = false
 android.useAndroidX=true
 android.enableJetifier=true
 
-version=2.2.10
+version=2.3.0
 group=dev.bluefalcon
 libraryName=blue-falcon
 kotlinx_coroutines_version=1.9.0

--- a/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -282,7 +282,7 @@ actual class BlueFalcon actual constructor(
         value: ByteArray,
         writeType: Int?
     ) {
-        log?.info("${mGattClientCallback.gattsForDevice(bluetoothPeripheral.device)} ${bluetoothPeripheral.uuid} Writing value {length = ${value.size}, bytes = 0x${value.toHexString()}} with response $writeType")
+        log?.info("[${bluetoothPeripheral.uuid}] Writing value {length = ${value.size}, bytes = 0x${value.toHexString()}} with response $writeType")
         mGattClientCallback.gattsForDevice(bluetoothPeripheral.device).forEach { gatt ->
             fetchCharacteristic(bluetoothCharacteristic, gatt)
                 .forEach {

--- a/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -34,11 +34,11 @@ actual class BlueFalcon actual constructor(
 
     actual fun requestConnectionPriority(
         bluetoothPeripheral: BluetoothPeripheral,
-        connectionPriority: Int
+        connectionPriority: ConnectionPriority
     ) {
         log?.info("requestConnectionPriority")
         mGattClientCallback.gattsForDevice(bluetoothPeripheral.device).forEach { gatt ->
-            gatt.requestConnectionPriority(connectionPriority)
+            gatt.requestConnectionPriority(connectionPriority.toNative())
         }
     }
 
@@ -280,7 +280,7 @@ actual class BlueFalcon actual constructor(
         value: ByteArray,
         writeType: Int?
     ) {
-        log?.info("Writing value {length = ${value.size}, bytes = 0x${value.toHexString()}} with response $writeType")
+        log?.info("${bluetoothPeripheral.uuid} Writing value {length = ${value.size}, bytes = 0x${value.toHexString()}} with response $writeType")
         mGattClientCallback.gattsForDevice(bluetoothPeripheral.device).forEach { gatt ->
             fetchCharacteristic(bluetoothCharacteristic, gatt)
                 .forEach {
@@ -377,8 +377,7 @@ actual class BlueFalcon actual constructor(
             gatts.filter { it.device.address == bluetoothDevice.address }
 
         override fun onConnectionStateChange(gatt: BluetoothGatt?, status: Int, newState: Int) {
-            super.onConnectionStateChange(gatt, status, newState)
-            log?.info("onConnectionStateChange")
+            log?.info("onConnectionStateChange status: $status newState: $newState")
             gatt?.let { bluetoothGatt ->
                 bluetoothGatt.device.let {
                     //BluetoothProfile#STATE_DISCONNECTED} or {@link BluetoothProfile#STATE_CONNECTED}
@@ -522,7 +521,7 @@ actual class BlueFalcon actual constructor(
             gatt: BluetoothGatt?,
             characteristic: BluetoothGattCharacteristic?
         ) {
-            log?.info("handleCharacteristicValueChange ${characteristic?.uuid}")
+            log?.info("handleCharacteristicValueChange ${characteristic?.uuid} ${characteristic?.value.contentToString()}")
             characteristic?.let { forcedCharacteristic ->
                 val characteristic = BluetoothCharacteristic(forcedCharacteristic)
                 gatt?.device?.let { bluetoothDevice ->

--- a/library/src/androidMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt
@@ -14,6 +14,7 @@ actual class BluetoothCharacteristic(val characteristic: BluetoothGattCharacteri
         get() = characteristic.value
     actual val descriptors: List<BluetoothCharacteristicDescriptor>
         get() = characteristic.descriptors
+    actual val service: BluetoothService? get() = BluetoothService(characteristic.service)
 
     internal actual val _descriptorsFlow = MutableStateFlow<List<BluetoothCharacteristicDescriptor>>(emptyList())
 
@@ -39,6 +40,15 @@ actual class BluetoothCharacteristic(val characteristic: BluetoothGattCharacteri
             return arrayOfNulls(size)
         }
     }
+
+    override fun equals(other: Any?): Boolean =
+        if (this === other) true
+        else if (other !is BluetoothCharacteristic) false
+        else characteristic.uuid == other.characteristic.uuid &&
+                characteristic.service.uuid == other.characteristic.service.uuid
+
+    override fun hashCode(): Int =
+        31 * characteristic.uuid.hashCode() + characteristic.service.uuid.hashCode()
 
     actual val uuid: Uuid
         get() = characteristic.uuid.toKotlinUuid()

--- a/library/src/androidMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -52,13 +52,7 @@ actual class BluetoothPeripheral actual constructor(val device: NativeBluetoothD
 
     actual val characteristics: Map<Uuid, List<BluetoothCharacteristic>>
         get() = services.values
-            .flatMap { service -> // Iterate through each service
-                service.characteristics.map { characteristic -> // For each characteristic in the service
-                    Pair(service.uuid, characteristic) // Create a pair of (serviceUUID, characteristic)
-                }
-            }
-            .groupBy { (_, characteristic) -> characteristic.uuid } // Group by characteristic UUID
-            .mapValues { entry -> // For each entry in the grouped map
-                entry.value.map { (_, characteristic) -> characteristic } // Extract only the characteristics
-            }
+            .flatMap { service -> service.characteristics }
+            .groupBy { characteristic -> characteristic.uuid } // Group by characteristic UUID
+            .mapValues { entry -> entry.value }
 }

--- a/library/src/androidMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -50,8 +50,15 @@ actual class BluetoothPeripheral actual constructor(val device: NativeBluetoothD
         }
     }
 
-    actual val characteristics: Map<Uuid, BluetoothCharacteristic>
+    actual val characteristics: Map<Uuid, List<BluetoothCharacteristic>>
         get() = services.values
-            .flatMap { it.characteristics }
-            .associateBy { it.uuid }
+            .flatMap { service -> // Iterate through each service
+                service.characteristics.map { characteristic -> // For each characteristic in the service
+                    Pair(service.uuid, characteristic) // Create a pair of (serviceUUID, characteristic)
+                }
+            }
+            .groupBy { (_, characteristic) -> characteristic.uuid } // Group by characteristic UUID
+            .mapValues { entry -> // For each entry in the grouped map
+                entry.value.map { (_, characteristic) -> characteristic } // Extract only the characteristics
+            }
 }

--- a/library/src/androidMain/kotlin/dev/bluefalcon/ConnectionPriority.android.kt
+++ b/library/src/androidMain/kotlin/dev/bluefalcon/ConnectionPriority.android.kt
@@ -1,0 +1,11 @@
+package dev.bluefalcon
+
+import android.bluetooth.BluetoothGatt.CONNECTION_PRIORITY_BALANCED
+import android.bluetooth.BluetoothGatt.CONNECTION_PRIORITY_HIGH
+import android.bluetooth.BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER
+
+actual fun ConnectionPriority.toNative(): Int = when (this) {
+    ConnectionPriority.Balanced -> CONNECTION_PRIORITY_BALANCED
+    ConnectionPriority.High -> CONNECTION_PRIORITY_HIGH
+    ConnectionPriority.Low -> CONNECTION_PRIORITY_LOW_POWER
+}

--- a/library/src/commonMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/commonMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -23,7 +23,7 @@ expect class BlueFalcon(
     fun connect(bluetoothPeripheral: BluetoothPeripheral, autoConnect: Boolean = false)
     fun disconnect(bluetoothPeripheral: BluetoothPeripheral)
 
-    fun requestConnectionPriority(bluetoothPeripheral: BluetoothPeripheral, connectionPriority: Int)
+    fun requestConnectionPriority(bluetoothPeripheral: BluetoothPeripheral, connectionPriority: ConnectionPriority)
 
     fun connectionState(bluetoothPeripheral: BluetoothPeripheral): BluetoothPeripheralState
 

--- a/library/src/commonMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt
+++ b/library/src/commonMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt
@@ -9,6 +9,7 @@ expect class BluetoothCharacteristic {
     val descriptors: List<BluetoothCharacteristicDescriptor>
     val isNotifying: Boolean
     internal val _descriptorsFlow: MutableStateFlow<List<BluetoothCharacteristicDescriptor>>
+    val service: BluetoothService?
 }
 
 expect class BluetoothCharacteristicDescriptor

--- a/library/src/commonMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/commonMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -10,7 +10,7 @@ expect class BluetoothPeripheral(device: NativeBluetoothDevice) {
     val services: Map<Uuid, BluetoothService>
     internal val _servicesFlow: MutableStateFlow<List<BluetoothService>>
 
-    val characteristics: Map<Uuid, BluetoothCharacteristic>
+    val characteristics: Map<Uuid, List<BluetoothCharacteristic>>
 }
 
 expect class NativeBluetoothDevice

--- a/library/src/commonMain/kotlin/dev/bluefalcon/ConnectionPriority.kt
+++ b/library/src/commonMain/kotlin/dev/bluefalcon/ConnectionPriority.kt
@@ -1,0 +1,9 @@
+package dev.bluefalcon
+
+enum class ConnectionPriority {
+    Balanced,
+    High,
+    Low
+}
+
+expect fun ConnectionPriority.toNative(): Int

--- a/library/src/jsMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/jsMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -45,7 +45,7 @@ actual class BlueFalcon actual constructor(
     @JsName("requestConnectionPriority")
     actual fun requestConnectionPriority(
         bluetoothPeripheral: BluetoothPeripheral,
-        connectionPriority: Int
+        connectionPriority: ConnectionPriority
     ) {
         // Not supported in Web Bluetooth API
     }

--- a/library/src/jsMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt
+++ b/library/src/jsMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt
@@ -17,6 +17,8 @@ actual class BluetoothCharacteristic(val characteristic: BluetoothRemoteGATTChar
     val stringValue get() = value?.decodeToString()
     internal actual val _descriptorsFlow = MutableStateFlow<List<BluetoothCharacteristicDescriptor>>(emptyList())
 
+    actual val service: BluetoothService? get() = null
+
     actual val uuid: Uuid
         get() = Uuid.parse(characteristic.uuid)
     actual val isNotifying: Boolean

--- a/library/src/jsMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/jsMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -22,13 +22,7 @@ actual class BluetoothPeripheral actual constructor(val device: NativeBluetoothD
 
     actual val characteristics: Map<Uuid, List<BluetoothCharacteristic>>
         get() = services.values
-            .flatMap { service -> // Iterate through each service
-                service.characteristics.map { characteristic -> // For each characteristic in the service
-                    Pair(service.uuid, characteristic) // Create a pair of (serviceUUID, characteristic)
-                }
-            }
-            .groupBy { (_, characteristic) -> characteristic.uuid } // Group by characteristic UUID
-            .mapValues { entry -> // For each entry in the grouped map
-                entry.value.map { (_, characteristic) -> characteristic } // Extract only the characteristics
-            }
+            .flatMap { service -> service.characteristics }
+            .groupBy { characteristic -> characteristic.uuid } // Group by characteristic UUID
+            .mapValues { entry -> entry.value }
 }

--- a/library/src/jsMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/jsMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -20,8 +20,15 @@ actual class BluetoothPeripheral actual constructor(val device: NativeBluetoothD
     actual val services: Map<Uuid, BluetoothService>
         get() = _servicesFlow.value.associateBy { it.uuid }
 
-    actual val characteristics: Map<Uuid, BluetoothCharacteristic>
+    actual val characteristics: Map<Uuid, List<BluetoothCharacteristic>>
         get() = services.values
-            .flatMap { it.characteristics }
-            .associateBy { it.uuid }
+            .flatMap { service -> // Iterate through each service
+                service.characteristics.map { characteristic -> // For each characteristic in the service
+                    Pair(service.uuid, characteristic) // Create a pair of (serviceUUID, characteristic)
+                }
+            }
+            .groupBy { (_, characteristic) -> characteristic.uuid } // Group by characteristic UUID
+            .mapValues { entry -> // For each entry in the grouped map
+                entry.value.map { (_, characteristic) -> characteristic } // Extract only the characteristics
+            }
 }

--- a/library/src/jsMain/kotlin/dev/bluefalcon/ConnectionPriority.js.kt
+++ b/library/src/jsMain/kotlin/dev/bluefalcon/ConnectionPriority.js.kt
@@ -1,0 +1,3 @@
+package dev.bluefalcon
+
+actual fun ConnectionPriority.toNative(): Int = 0

--- a/library/src/nativeMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/nativeMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -35,7 +35,7 @@ actual class BlueFalcon actual constructor(
 
     actual fun requestConnectionPriority(
         bluetoothPeripheral: BluetoothPeripheral,
-        connectionPriority: Int
+        connectionPriority: ConnectionPriority
     ) { }
 
     actual fun connectionState(bluetoothPeripheral: BluetoothPeripheral): BluetoothPeripheralState =

--- a/library/src/nativeMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt
+++ b/library/src/nativeMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt
@@ -23,6 +23,8 @@ actual class BluetoothCharacteristic(val characteristic: CBCharacteristic) {
     actual val descriptors: List<BluetoothCharacteristicDescriptor>
         get() = characteristic.descriptors as List<BluetoothCharacteristicDescriptor>
 
+    actual val service: BluetoothService? get() = characteristic.service?.let { BluetoothService(it) }
+
     internal actual val _descriptorsFlow = MutableStateFlow<List<BluetoothCharacteristicDescriptor>>(emptyList())
 
     actual val uuid: Uuid

--- a/library/src/nativeMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/nativeMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -29,8 +29,15 @@ actual class BluetoothPeripheral(val bluetoothDevice: CBPeripheral, val rssiValu
             ?.associateBy { it.uuid }
             ?: emptyMap()
 
-    actual val characteristics: Map<Uuid, BluetoothCharacteristic>
+    actual val characteristics: Map<Uuid, List<BluetoothCharacteristic>>
         get() = services.values
-            .flatMap { it.characteristics }
-            .associateBy { it.uuid }
+            .flatMap { service -> // Iterate through each service
+                service.characteristics.map { characteristic -> // For each characteristic in the service
+                    Pair(service.uuid, characteristic) // Create a pair of (serviceUUID, characteristic)
+                }
+            }
+            .groupBy { (_, characteristic) -> characteristic.uuid } // Group by characteristic UUID
+            .mapValues { entry -> // For each entry in the grouped map
+                entry.value.map { (_, characteristic) -> characteristic } // Extract only the characteristics
+            }
 }

--- a/library/src/nativeMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/nativeMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -31,13 +31,7 @@ actual class BluetoothPeripheral(val bluetoothDevice: CBPeripheral, val rssiValu
 
     actual val characteristics: Map<Uuid, List<BluetoothCharacteristic>>
         get() = services.values
-            .flatMap { service -> // Iterate through each service
-                service.characteristics.map { characteristic -> // For each characteristic in the service
-                    Pair(service.uuid, characteristic) // Create a pair of (serviceUUID, characteristic)
-                }
-            }
-            .groupBy { (_, characteristic) -> characteristic.uuid } // Group by characteristic UUID
-            .mapValues { entry -> // For each entry in the grouped map
-                entry.value.map { (_, characteristic) -> characteristic } // Extract only the characteristics
-            }
+            .flatMap { service -> service.characteristics }
+            .groupBy { characteristic -> characteristic.uuid } // Group by characteristic UUID
+            .mapValues { entry -> entry.value }
 }

--- a/library/src/nativeMain/kotlin/dev/bluefalcon/ConnectionPriority.native.kt
+++ b/library/src/nativeMain/kotlin/dev/bluefalcon/ConnectionPriority.native.kt
@@ -1,0 +1,3 @@
+package dev.bluefalcon
+
+actual fun ConnectionPriority.toNative(): Int = 0

--- a/library/src/rpiMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
+++ b/library/src/rpiMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt
@@ -17,6 +17,7 @@ actual class BluetoothPeripheral actual constructor(val device: NativeBluetoothD
 
     actual val characteristics: Map<Uuid, BluetoothCharacteristic>
         get() = services.values
-            .flatMap { it.characteristics }
-            .associateBy { it.uuid }
+            .flatMap { service -> service.characteristics }
+            .groupBy { characteristic -> characteristic.uuid } // Group by characteristic UUID
+            .mapValues { entry -> entry.value }
 }


### PR DESCRIPTION
This pull request introduces several updates to the `BlueFalcon` library, focusing on improving Bluetooth characteristic handling, adding connection priority support, and refining logging for better debugging. The changes enhance functionality across multiple platforms (`androidMain`, `commonMain`, `jsMain`, and `nativeMain`) and include updates to the API, internal logic, and logging mechanisms.

### Bluetooth characteristic handling:

* [`library/src/commonMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt`](diffhunk://#diff-e6eb23c2aa0e615af683afe24b79f7aea3fd8a30260d6802c10583ed348089feR12): Added a `service` property to link characteristics to their respective services. Updated the `equals` and `hashCode` methods to include service UUIDs for better comparison logic. [[1]](diffhunk://#diff-e6eb23c2aa0e615af683afe24b79f7aea3fd8a30260d6802c10583ed348089feR12) [[2]](diffhunk://#diff-c05427dd9bb96277db5d27b375fea990a18ffacc3e92e6fbb87f0c0617057f92R17) [[3]](diffhunk://#diff-c05427dd9bb96277db5d27b375fea990a18ffacc3e92e6fbb87f0c0617057f92R44-R52)
* [`library/src/commonMain/kotlin/dev/bluefalcon/BluetoothPeripheral.kt`](diffhunk://#diff-c065e5aa737ca731df806fc4d48b79289ba7d45e6a87ceeb26bfae90d044b23dL13-R13): Changed the `characteristics` property to group characteristics by UUID, allowing multiple characteristics with the same UUID to be associated with their services. [[1]](diffhunk://#diff-c065e5aa737ca731df806fc4d48b79289ba7d45e6a87ceeb26bfae90d044b23dL13-R13) [[2]](diffhunk://#diff-f029aff6dab4a32f4841dda7fb538754b0f2b25fcf59dc25a4532033e44b8196L53-R63) [[3]](diffhunk://#diff-a08ee4a007a7c025daae98724774d75830d4ebabbd00dc7bdecca3c642347d5dL23-R33) [[4]](diffhunk://#diff-f945aa7d869e74b35322e9730818ce5abf94100df4735a77294ac199e2a153d0L32-R42)

### Connection priority support:

* [`library/src/commonMain/kotlin/dev/bluefalcon/ConnectionPriority.kt`](diffhunk://#diff-9da1268205cc1050d2657fa3997a60f89cc3c8cc73eb040879690e297e7e0437R1-R9): Introduced a new `ConnectionPriority` enum with values `Balanced`, `High`, and `Low`, along with an `expect` function `toNative()` for platform-specific implementations.
* [`library/src/androidMain/kotlin/dev/bluefalcon/ConnectionPriority.android.kt`](diffhunk://#diff-5a67e81a6e5faa9525712c28fef938e0190a6078b9f67ed67feb8014451e2b64R1-R11): Implemented the `toNative()` function to map `ConnectionPriority` values to Android's `BluetoothGatt` constants.
* Updated `requestConnectionPriority` in `BlueFalcon` across all platforms to use the new `ConnectionPriority` type instead of `Int`. [[1]](diffhunk://#diff-910f5d3552891bbe6c182e02034e63c757c41d96cc9e1541373f78d68d67375eL37-R41) [[2]](diffhunk://#diff-427255e71278203f2e1d05c23a1dd4a0aebfa80b6e698214d3e919e2dc68f654L26-R26) [[3]](diffhunk://#diff-5d54d5a809940748545badc2c68ef474e5549e73f4c6a4c756661f5167c3d9fcL48-R48) [[4]](diffhunk://#diff-683c9ffdcc1b914925610a1714823473a5d81dcd660dcdb77e554aebf76d4296L38-R38)

### Logging refinements:

* Enhanced logging throughout `BlueFalcon` to include additional context, such as device addresses and UUIDs, for better debugging. Examples include updates to `onConnectionStateChange`, `onDescriptorWrite`, and `handleCharacteristicValueChange`. [[1]](diffhunk://#diff-910f5d3552891bbe6c182e02034e63c757c41d96cc9e1541373f78d68d67375eL128-R134) [[2]](diffhunk://#diff-910f5d3552891bbe6c182e02034e63c757c41d96cc9e1541373f78d68d67375eL150-R152) [[3]](diffhunk://#diff-910f5d3552891bbe6c182e02034e63c757c41d96cc9e1541373f78d68d67375eL283-R285) [[4]](diffhunk://#diff-910f5d3552891bbe6c182e02034e63c757c41d96cc9e1541373f78d68d67375eL380-R382) [[5]](diffhunk://#diff-910f5d3552891bbe6c182e02034e63c757c41d96cc9e1541373f78d68d67375eL490-R491) [[6]](diffhunk://#diff-910f5d3552891bbe6c182e02034e63c757c41d96cc9e1541373f78d68d67375eL525-R526)

### Platform-specific updates:

* [`library/src/jsMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.kt`](diffhunk://#diff-24eb610e7cf2fdb9ca4c64c4b134d2a752735123d190118cb8c2be33c7d06d77R20-R21): Added a stub implementation for the `service` property, returning `null` since services aren't supported in Web Bluetooth API.
* [`library/src/jsMain/kotlin/dev/bluefalcon/ConnectionPriority.js.kt`](diffhunk://#diff-d0e51076a056b900139788822366f547a5d5b9cbc4c03d758098e33eb0a2e433R1-R3): Added a stub implementation for `toNative()` returning a default value.
* [`library/src/nativeMain/kotlin/dev/bluefalcon/ConnectionPriority.native.kt`](diffhunk://#diff-d0e51076a056b900139788822366f547a5d5b9cbc4c03d758098e33eb0a2e433R1-R3): Added a stub implementation for `toNative()` returning a default value.

### Miscellaneous:

* [`library/gradle.properties`](diffhunk://#diff-e73b843a5f975f3e6aa3ee4fcc407e19890e290037f2da1b92a87c887eb54966L13-R13): Updated the library version from `2.2.9` to `2.3.0`.