### PR TITLE
iOS: Add delegate callback for characteristic write events

### DIFF
--- a/library/src/nativeMain/kotlin/dev/bluefalcon/PeripheralDelegate.kt
+++ b/library/src/nativeMain/kotlin/dev/bluefalcon/PeripheralDelegate.kt
@@ -1,5 +1,6 @@
 package dev.bluefalcon
 
+import kotlinx.cinterop.ObjCSignatureOverride
 import platform.CoreBluetooth.*
 import platform.Foundation.NSError
 import platform.darwin.NSObject
@@ -46,6 +47,28 @@ class PeripheralDelegate constructor(
         }
     }
 
+    @ObjCSignatureOverride
+    override fun peripheral(
+        peripheral: CBPeripheral,
+        didWriteValueForCharacteristic: CBCharacteristic,
+        error: NSError?
+    ) {
+        if (error != null) {
+            log?.error("Error with characteristic write $error")
+        }
+        log?.info("handleCharacteristicValueWrite ${didWriteValueForCharacteristic.UUID}")
+        val device = BluetoothPeripheral(peripheral, rssiValue = null)
+        val characteristic = BluetoothCharacteristic(didWriteValueForCharacteristic)
+        blueFalcon.delegates.forEach {
+            it.didWriteCharacteristic(
+                device,
+                characteristic,
+                error != null,
+            )
+        }
+    }
+
+    @ObjCSignatureOverride
     override fun peripheral(
         peripheral: CBPeripheral,
         didUpdateValueForCharacteristic: CBCharacteristic,


### PR DESCRIPTION
# Description

This PR adds support for handling **characteristic write acknowledgments on iOS**.

- Implements `peripheral(_:didWriteValueForCharacteristic:error:)` in `PeripheralDelegate`.
- Notifies all registered BlueFalcon delegates via `didWriteCharacteristic`
- Logs success or error states when a characteristic write occurs.

# Motivation

Previously, BlueFalcon on iOS did not expose write completion events to delegates. This made it difficult for applications to track when writes were acknowledged or failed. With this update, apps can now reliably react to write results.
