### PR TITLE
Add linuxX64 and linuxArm64 targets via sdbus-kotlin and BlueZ

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -3,9 +3,11 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     kotlin("multiplatform") version "2.3.0"
+    kotlin("plugin.serialization") version "2.3.0"
     id("com.android.library")
     id("com.vanniktech.maven.publish") version "0.34.0"
     id("signing")
+    id("com.monkopedia.sdbus.plugin") version "0.4.2"
 }
 
 repositories {
@@ -77,6 +79,8 @@ kotlin {
     iosArm64()
     macosArm64()
     macosX64()
+    linuxX64()
+    linuxArm64()
 
     sourceSets {
         val commonMain by getting {
@@ -102,7 +106,25 @@ kotlin {
 //            }
 //        }
         val jsMain by getting
+        val linuxX64Main by getting
+        val linuxArm64Main by getting
+        val linuxMain by creating {
+            dependsOn(commonMain)
+            linuxX64Main.dependsOn(this)
+            linuxArm64Main.dependsOn(this)
+            dependencies {
+                implementation("com.monkopedia:sdbus-kotlin:0.4.2")
+            }
+        }
     }
+}
+
+sdbus {
+    sources.srcDirs("src/dbusMain")
+    outputs.add("linuxMain")
+    generateProxies = true
+    generateAdapters = true
+    outputPackage = "dev.bluefalcon.bluez"
 }
 
 mavenPublishing {

--- a/library/src/dbusMain/org.bluez.Adapter1.xml
+++ b/library/src/dbusMain/org.bluez.Adapter1.xml
@@ -1,0 +1,30 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.bluez.Adapter1">
+    <method name="StartDiscovery"/>
+    <method name="StopDiscovery"/>
+    <method name="SetDiscoveryFilter">
+      <arg name="properties" type="a{sv}" direction="in"/>
+    </method>
+    <method name="RemoveDevice">
+      <arg name="device" type="o" direction="in"/>
+    </method>
+    <method name="GetDiscoveryFilters">
+      <arg name="filters" type="as" direction="out"/>
+    </method>
+    <property name="Address" type="s" access="read"/>
+    <property name="AddressType" type="s" access="read"/>
+    <property name="Name" type="s" access="read"/>
+    <property name="Alias" type="s" access="readwrite"/>
+    <property name="Class" type="u" access="read"/>
+    <property name="Powered" type="b" access="readwrite"/>
+    <property name="Discoverable" type="b" access="readwrite"/>
+    <property name="DiscoverableTimeout" type="u" access="readwrite"/>
+    <property name="Pairable" type="b" access="readwrite"/>
+    <property name="PairableTimeout" type="u" access="readwrite"/>
+    <property name="Discovering" type="b" access="read"/>
+    <property name="UUIDs" type="as" access="read"/>
+    <property name="Modalias" type="s" access="read"/>
+  </interface>
+</node>

--- a/library/src/dbusMain/org.bluez.Agent1.xml
+++ b/library/src/dbusMain/org.bluez.Agent1.xml
@@ -1,0 +1,36 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.bluez.Agent1">
+    <method name="Release"/>
+    <method name="RequestPinCode">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="pincode" type="s" direction="out"/>
+    </method>
+    <method name="DisplayPinCode">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="pincode" type="s" direction="in"/>
+    </method>
+    <method name="RequestPasskey">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="passkey" type="u" direction="out"/>
+    </method>
+    <method name="DisplayPasskey">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="passkey" type="u" direction="in"/>
+      <arg name="entered" type="q" direction="in"/>
+    </method>
+    <method name="RequestConfirmation">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="passkey" type="u" direction="in"/>
+    </method>
+    <method name="RequestAuthorization">
+      <arg name="device" type="o" direction="in"/>
+    </method>
+    <method name="AuthorizeService">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="uuid" type="s" direction="in"/>
+    </method>
+    <method name="Cancel"/>
+  </interface>
+</node>

--- a/library/src/dbusMain/org.bluez.AgentManager1.xml
+++ b/library/src/dbusMain/org.bluez.AgentManager1.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.bluez.AgentManager1">
+    <method name="RegisterAgent">
+      <arg name="agent" type="o" direction="in"/>
+      <arg name="capability" type="s" direction="in"/>
+    </method>
+    <method name="UnregisterAgent">
+      <arg name="agent" type="o" direction="in"/>
+    </method>
+    <method name="RequestDefaultAgent">
+      <arg name="agent" type="o" direction="in"/>
+    </method>
+  </interface>
+</node>

--- a/library/src/dbusMain/org.bluez.Device1.xml
+++ b/library/src/dbusMain/org.bluez.Device1.xml
@@ -1,0 +1,38 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.bluez.Device1">
+    <method name="Connect"/>
+    <method name="Disconnect"/>
+    <method name="ConnectProfile">
+      <arg name="UUID" type="s" direction="in"/>
+    </method>
+    <method name="DisconnectProfile">
+      <arg name="UUID" type="s" direction="in"/>
+    </method>
+    <method name="Pair"/>
+    <method name="CancelPairing"/>
+    <property name="Address" type="s" access="read"/>
+    <property name="AddressType" type="s" access="read"/>
+    <property name="Name" type="s" access="read"/>
+    <property name="Alias" type="s" access="readwrite"/>
+    <property name="Class" type="u" access="read"/>
+    <property name="Appearance" type="q" access="read"/>
+    <property name="Icon" type="s" access="read"/>
+    <property name="Paired" type="b" access="read"/>
+    <property name="Trusted" type="b" access="readwrite"/>
+    <property name="Blocked" type="b" access="readwrite"/>
+    <property name="LegacyPairing" type="b" access="read"/>
+    <property name="RSSI" type="n" access="read"/>
+    <property name="Connected" type="b" access="read"/>
+    <property name="UUIDs" type="as" access="read"/>
+    <property name="Modalias" type="s" access="read"/>
+    <property name="Adapter" type="o" access="read"/>
+    <property name="ManufacturerData" type="a{qv}" access="read"/>
+    <property name="ServiceData" type="a{sv}" access="read"/>
+    <property name="TxPower" type="n" access="read"/>
+    <property name="ServicesResolved" type="b" access="read"/>
+    <property name="AdvertisingFlags" type="ay" access="read"/>
+    <property name="AdvertisingData" type="a{yv}" access="read"/>
+  </interface>
+</node>

--- a/library/src/dbusMain/org.bluez.GattCharacteristic1.xml
+++ b/library/src/dbusMain/org.bluez.GattCharacteristic1.xml
@@ -1,0 +1,34 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.bluez.GattCharacteristic1">
+    <method name="ReadValue">
+      <arg name="options" type="a{sv}" direction="in"/>
+      <arg name="value" type="ay" direction="out"/>
+    </method>
+    <method name="WriteValue">
+      <arg name="value" type="ay" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+    <method name="AcquireWrite">
+      <arg name="options" type="a{sv}" direction="in"/>
+      <arg name="fd" type="h" direction="out"/>
+      <arg name="mtu" type="q" direction="out"/>
+    </method>
+    <method name="AcquireNotify">
+      <arg name="options" type="a{sv}" direction="in"/>
+      <arg name="fd" type="h" direction="out"/>
+      <arg name="mtu" type="q" direction="out"/>
+    </method>
+    <method name="StartNotify"/>
+    <method name="StopNotify"/>
+    <property name="UUID" type="s" access="read"/>
+    <property name="Service" type="o" access="read"/>
+    <property name="Value" type="ay" access="read"/>
+    <property name="WriteAcquired" type="b" access="read"/>
+    <property name="NotifyAcquired" type="b" access="read"/>
+    <property name="Notifying" type="b" access="read"/>
+    <property name="Flags" type="as" access="read"/>
+    <property name="MTU" type="q" access="read"/>
+  </interface>
+</node>

--- a/library/src/dbusMain/org.bluez.GattDescriptor1.xml
+++ b/library/src/dbusMain/org.bluez.GattDescriptor1.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.bluez.GattDescriptor1">
+    <method name="ReadValue">
+      <arg name="options" type="a{sv}" direction="in"/>
+      <arg name="value" type="ay" direction="out"/>
+    </method>
+    <method name="WriteValue">
+      <arg name="value" type="ay" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+    </method>
+    <property name="UUID" type="s" access="read"/>
+    <property name="Characteristic" type="o" access="read"/>
+    <property name="Value" type="ay" access="read"/>
+    <property name="Flags" type="as" access="read"/>
+  </interface>
+</node>

--- a/library/src/dbusMain/org.bluez.GattService1.xml
+++ b/library/src/dbusMain/org.bluez.GattService1.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.bluez.GattService1">
+    <property name="UUID" type="s" access="read"/>
+    <property name="Primary" type="b" access="read"/>
+    <property name="Device" type="o" access="read"/>
+    <property name="Includes" type="ao" access="read"/>
+  </interface>
+</node>

--- a/library/src/dbusMain/org.freedesktop.DBus.ObjectManager.xml
+++ b/library/src/dbusMain/org.freedesktop.DBus.ObjectManager.xml
@@ -1,0 +1,17 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.freedesktop.DBus.ObjectManager">
+    <method name="GetManagedObjects">
+      <arg name="objects" type="a{oa{sa{sv}}}" direction="out"/>
+    </method>
+    <signal name="InterfacesAdded">
+      <arg name="object" type="o"/>
+      <arg name="interfaces" type="a{sa{sv}}"/>
+    </signal>
+    <signal name="InterfacesRemoved">
+      <arg name="object" type="o"/>
+      <arg name="interfaces" type="as"/>
+    </signal>
+  </interface>
+</node>

--- a/library/src/dbusMain/org.freedesktop.DBus.Properties.xml
+++ b/library/src/dbusMain/org.freedesktop.DBus.Properties.xml
@@ -1,0 +1,25 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface" type="s" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="value" type="v" direction="out"/>
+    </method>
+    <method name="Set">
+      <arg name="interface" type="s" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="value" type="v" direction="in"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface" type="s" direction="in"/>
+      <arg name="properties" type="a{sv}" direction="out"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+</node>

--- a/library/src/linuxMain/kotlin/dev/bluefalcon/ApplicationContext.kt
+++ b/library/src/linuxMain/kotlin/dev/bluefalcon/ApplicationContext.kt
@@ -1,0 +1,8 @@
+package dev.bluefalcon
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+
+actual class ApplicationContext(
+    val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+)

--- a/library/src/linuxMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/linuxMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -1,0 +1,650 @@
+package dev.bluefalcon
+
+import com.monkopedia.sdbus.InterfaceName
+import com.monkopedia.sdbus.ObjectPath
+import com.monkopedia.sdbus.PropertyName
+import com.monkopedia.sdbus.ServiceName
+import com.monkopedia.sdbus.Variant
+import com.monkopedia.sdbus.createObject
+import com.monkopedia.sdbus.createProxy
+import com.monkopedia.sdbus.createSystemBusConnection
+import dev.bluefalcon.bluez.*
+import com.monkopedia.sdbus.ObjectManagerProxy as SdbusObjectManagerProxy
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlin.uuid.Uuid
+
+actual class BlueFalcon actual constructor(
+    private val log: Logger?,
+    private val context: ApplicationContext,
+    private val autoDiscoverAllServicesAndCharacteristics: Boolean
+) {
+    actual val scope = CoroutineScope(
+        context.scope.coroutineContext + SupervisorJob(context.scope.coroutineContext[Job])
+    )
+    actual val delegates: MutableSet<BlueFalconDelegate> = mutableSetOf()
+    actual var isScanning: Boolean = false
+
+    internal actual val _peripherals = MutableStateFlow<Set<BluetoothPeripheral>>(emptySet())
+    actual val peripherals: NativeFlow<Set<BluetoothPeripheral>> = _peripherals.toNativeType(scope)
+    actual val managerState: StateFlow<BluetoothManagerState> =
+        MutableStateFlow(BluetoothManagerState.Ready)
+
+    private val connection = createSystemBusConnection()
+    private val bluezService = ServiceName("org.bluez")
+    private val adapterPath = ObjectPath("/org/bluez/hci0")
+    private lateinit var adapterProxy: Adapter1Proxy
+    private lateinit var objectManagerProxy: SdbusObjectManagerProxy
+
+    private val knownPeripherals = mutableMapOf<ObjectPath, BluetoothPeripheralImpl>()
+    private val connectedDevices = mutableMapOf<ObjectPath, ConnectedDevice>()
+    private var scanJob: Job? = null
+
+    /** Holds the proxy and observation scope for a connected device. */
+    private class ConnectedDevice(
+        val proxy: Device1Proxy,
+        val observationScope: Job,
+    )
+
+    private val initJob = scope.launch {
+        // The D-Bus event loop must be shut down before a new connection
+        // can safely be used. BlueZ's disconnect is synchronous at the D-Bus
+        // level but leaveEventLoop() is async, so we wait here to ensure the
+        // previous instance's event loop has fully stopped.
+        pendingShutdown?.join()
+        pendingShutdown = null
+
+        adapterProxy = Adapter1Proxy(
+            createProxy(connection, bluezService, adapterPath)
+        )
+        objectManagerProxy = SdbusObjectManagerProxy(
+            createProxy(connection, bluezService, ObjectPath("/"))
+        )
+        connection.enterEventLoopAsync()
+
+        // Agent registration is fire-and-forget — pairing will work once
+        // the agent is registered, but other operations don't depend on it.
+        registerAgent()
+    }
+
+    /**
+     * Registers a NoInputNoOutput pairing agent with BlueZ.
+     *
+     * blue-falcon's API only exposes createBond/removeBond with no passkey
+     * or PIN callbacks, so NoInputNoOutput (Just Works) is the only
+     * pairing mode we can support.
+     */
+    private fun registerAgent() {
+        val agentPath = ObjectPath("/dev/bluefalcon/agent")
+        val agent = NoInputNoOutputAgent(createObject(connection, agentPath))
+        agent.register()
+        val agentManager = AgentManager1Proxy(
+            createProxy(connection, bluezService, ObjectPath("/org/bluez"))
+        )
+        scope.launch {
+            try {
+                agentManager.registerAgent(agentPath, "NoInputNoOutput")
+                agentManager.requestDefaultAgent(agentPath)
+                log?.info("Registered NoInputNoOutput pairing agent")
+            } catch (e: Exception) {
+                log?.error("Failed to register pairing agent: ${e.message}", e)
+            }
+        }
+    }
+
+    // ---- Scanning ----
+
+    actual fun scan(filters: List<ServiceFilter>) {
+        log?.info("Scan started with filters: $filters")
+        isScanning = true
+
+        scanJob = scope.launch {
+            initJob.join()
+            try {
+                configureDiscoveryFilter(filters)
+                startDiscovery()
+
+                val deviceInterface = InterfaceName("org.bluez.Device1")
+                objectManagerProxy.objectsFor(deviceInterface).collectLatest { paths ->
+                    coroutineScope {
+                        for (path in paths) {
+                            if (!path.value.startsWith(adapterPath.value + "/dev_")) continue
+                            launch {
+                                objectManagerProxy.objectData(path).collect { data ->
+                                    val devProps = data[deviceInterface] ?: return@collect
+                                    handleDeviceFound(path, devProps)
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                log?.error("Scan failed: ${e.message}", e)
+                isScanning = false
+            }
+        }
+    }
+
+    actual fun stopScanning() {
+        log?.info("Scan stopped")
+        isScanning = false
+        scope.launch {
+            try { adapterProxy.stopDiscovery() } catch (_: Exception) {}
+            scanJob?.cancel()
+            scanJob = null
+        }
+    }
+
+    actual fun clearPeripherals() {
+        _peripherals.value = emptySet()
+    }
+
+    // ---- Connection ----
+
+    actual fun connect(bluetoothPeripheral: BluetoothPeripheral, autoConnect: Boolean) {
+        val impl = bluetoothPeripheral as BluetoothPeripheralImpl
+        log?.info("Connecting to ${impl.uuid}")
+
+        scope.launch {
+            initJob.join()
+            try {
+                // Cancel any existing connection to this device
+                connectedDevices.remove(impl.device.objectPath)?.observationScope?.cancel()
+
+                val deviceProxy = Device1Proxy(
+                    createProxy(connection, bluezService, impl.device.objectPath)
+                )
+                val observationScope = observeDeviceProperties(impl, deviceProxy)
+                connectedDevices[impl.device.objectPath] = ConnectedDevice(deviceProxy, observationScope)
+                deviceProxy.connect()
+            } catch (e: Exception) {
+                log?.error("Connect failed: ${e.message}", e)
+            }
+        }
+    }
+
+    actual fun disconnect(bluetoothPeripheral: BluetoothPeripheral) {
+        val impl = bluetoothPeripheral as BluetoothPeripheralImpl
+        scope.launch {
+            // Use NonCancellable so scope.cancel() in destroy() doesn't
+            // kill the D-Bus disconnect call mid-flight
+            withContext(NonCancellable) {
+                try {
+                    val device = connectedDevices.remove(impl.device.objectPath)
+                    device?.observationScope?.cancel()
+                    device?.proxy?.disconnect()
+                } catch (e: Exception) {
+                    log?.error("Disconnect failed: ${e.message}", e)
+                }
+            }
+            // Always notify, matching Android behavior
+            notifyDelegates { it.didDisconnect(bluetoothPeripheral) }
+        }
+    }
+
+    actual fun retrievePeripheral(identifier: String): BluetoothPeripheral? {
+        val devPath = ObjectPath(
+            "${adapterPath.value}/dev_${identifier.replace(":", "_")}"
+        )
+        return knownPeripherals[devPath]
+    }
+
+    actual fun connectionState(bluetoothPeripheral: BluetoothPeripheral): BluetoothPeripheralState {
+        val impl = bluetoothPeripheral as BluetoothPeripheralImpl
+        val device = connectedDevices[impl.device.objectPath]
+        return try {
+            if (device?.proxy?.connected == true) BluetoothPeripheralState.Connected
+            else BluetoothPeripheralState.Disconnected
+        } catch (_: Exception) {
+            BluetoothPeripheralState.Unknown
+        }
+    }
+
+    actual fun requestConnectionPriority(
+        bluetoothPeripheral: BluetoothPeripheral,
+        connectionPriority: ConnectionPriority
+    ) {
+        // No BlueZ equivalent — connection parameters are managed by the kernel.
+    }
+
+    // ---- Service / Characteristic Discovery ----
+
+    actual fun discoverServices(
+        bluetoothPeripheral: BluetoothPeripheral,
+        serviceUUIDs: List<Uuid>
+    ) {
+        val impl = bluetoothPeripheral as BluetoothPeripheralImpl
+        scope.launch {
+            resolveGattObjects(impl)
+            notifyDelegates { it.didDiscoverServices(bluetoothPeripheral) }
+        }
+    }
+
+    actual fun discoverCharacteristics(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothService: BluetoothService,
+        characteristicUUIDs: List<Uuid>
+    ) {
+        notifyDelegates { it.didDiscoverCharacteristics(bluetoothPeripheral) }
+    }
+
+    // ---- Read / Write ----
+
+    actual fun readCharacteristic(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic
+    ) {
+        scope.launch {
+            try {
+                val charProxy = createCharProxy(bluetoothCharacteristic)
+                val value = charProxy.readValue(emptyMap())
+                bluetoothCharacteristic._value = value.toUByteArray().asByteArray()
+                notifyDelegates {
+                    it.didCharacteristcValueChanged(bluetoothPeripheral, bluetoothCharacteristic)
+                }
+            } catch (e: Exception) {
+                log?.error("Read characteristic failed: ${e.message}", e)
+            }
+        }
+    }
+
+    actual fun writeCharacteristic(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        value: String,
+        writeType: Int?
+    ) {
+        writeCharacteristicWithoutEncoding(
+            bluetoothPeripheral, bluetoothCharacteristic,
+            value.encodeToByteArray(), writeType
+        )
+    }
+
+    actual fun writeCharacteristic(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        value: ByteArray,
+        writeType: Int?
+    ) {
+        writeCharacteristicWithoutEncoding(
+            bluetoothPeripheral, bluetoothCharacteristic, value, writeType
+        )
+    }
+
+    actual fun writeCharacteristicWithoutEncoding(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        value: ByteArray,
+        writeType: Int?
+    ) {
+        scope.launch {
+            try {
+                val charProxy = createCharProxy(bluetoothCharacteristic)
+                val options = mutableMapOf<String, Variant>()
+                if (writeType == 1) {
+                    options["type"] = Variant("command")
+                } else {
+                    options["type"] = Variant("request")
+                }
+                charProxy.writeValue(value.asUByteArray().toList(), options)
+                bluetoothCharacteristic._value = value
+                notifyDelegates {
+                    it.didWriteCharacteristic(bluetoothPeripheral, bluetoothCharacteristic, true)
+                }
+            } catch (e: Exception) {
+                log?.error("Write failed: ${e.message}", e)
+                notifyDelegates {
+                    it.didWriteCharacteristic(bluetoothPeripheral, bluetoothCharacteristic, false)
+                }
+            }
+        }
+    }
+
+    // ---- Notify / Indicate ----
+
+    actual fun notifyCharacteristic(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        notify: Boolean
+    ) {
+        scope.launch {
+            try {
+                val charProxy = createCharProxy(bluetoothCharacteristic)
+                if (notify && !bluetoothCharacteristic.isNotifying) {
+                    val job = scope.launch {
+                        charProxy.valueProperty.changes().collect { value ->
+                            bluetoothCharacteristic._value = value.toUByteArray().asByteArray()
+                            notifyDelegates {
+                                it.didCharacteristcValueChanged(
+                                    bluetoothPeripheral, bluetoothCharacteristic
+                                )
+                            }
+                        }
+                    }
+                    bluetoothCharacteristic._notifyJob = job
+                    charProxy.startNotify()
+                    bluetoothCharacteristic._isNotifying = true
+                } else if (!notify && bluetoothCharacteristic.isNotifying) {
+                    charProxy.stopNotify()
+                    bluetoothCharacteristic._isNotifying = false
+                    bluetoothCharacteristic._notifyJob?.cancel()
+                    bluetoothCharacteristic._notifyJob = null
+                }
+                notifyDelegates {
+                    it.didUpdateNotificationStateFor(bluetoothPeripheral, bluetoothCharacteristic)
+                }
+            } catch (e: Exception) {
+                log?.error("Notify failed: ${e.message}", e)
+            }
+        }
+    }
+
+    actual fun indicateCharacteristic(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        indicate: Boolean
+    ) {
+        // BlueZ StartNotify handles both notify and indicate
+        notifyCharacteristic(bluetoothPeripheral, bluetoothCharacteristic, indicate)
+    }
+
+    actual fun notifyAndIndicateCharacteristic(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        enable: Boolean
+    ) {
+        notifyCharacteristic(bluetoothPeripheral, bluetoothCharacteristic, enable)
+    }
+
+    // ---- Descriptors ----
+
+    actual fun readDescriptor(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristic: BluetoothCharacteristic,
+        bluetoothCharacteristicDescriptor: BluetoothCharacteristicDescriptor
+    ) {
+        scope.launch {
+            try {
+                val descProxy = GattDescriptor1Proxy(
+                    createProxy(connection, bluezService, bluetoothCharacteristicDescriptor.objectPath)
+                )
+                val value = descProxy.readValue(emptyMap())
+                bluetoothCharacteristicDescriptor._value = value.toUByteArray().asByteArray()
+                notifyDelegates {
+                    it.didReadDescriptor(bluetoothPeripheral, bluetoothCharacteristicDescriptor)
+                }
+            } catch (e: Exception) {
+                log?.error("Read descriptor failed: ${e.message}", e)
+            }
+        }
+    }
+
+    actual fun writeDescriptor(
+        bluetoothPeripheral: BluetoothPeripheral,
+        bluetoothCharacteristicDescriptor: BluetoothCharacteristicDescriptor,
+        value: ByteArray
+    ) {
+        scope.launch {
+            try {
+                val descProxy = GattDescriptor1Proxy(
+                    createProxy(connection, bluezService, bluetoothCharacteristicDescriptor.objectPath)
+                )
+                descProxy.writeValue(value.asUByteArray().toList(), emptyMap())
+                bluetoothCharacteristicDescriptor._value = value
+                notifyDelegates {
+                    it.didWriteDescriptor(bluetoothPeripheral, bluetoothCharacteristicDescriptor)
+                }
+            } catch (e: Exception) {
+                log?.error("Write descriptor failed: ${e.message}", e)
+            }
+        }
+    }
+
+    // ---- MTU ----
+
+    actual fun changeMTU(bluetoothPeripheral: BluetoothPeripheral, mtuSize: Int) {
+        val impl = bluetoothPeripheral as BluetoothPeripheralImpl
+        scope.launch {
+            try {
+                val firstChar = impl.services.values.flatMap { it.characteristics }.firstOrNull()
+                if (firstChar != null) {
+                    val charProxy = createCharProxy(firstChar)
+                    impl.mtuSize = charProxy.mTU.toInt()
+                }
+                notifyDelegates { it.didUpdateMTU(bluetoothPeripheral, 0) }
+            } catch (e: Exception) {
+                log?.error("changeMTU failed: ${e.message}", e)
+                notifyDelegates { it.didUpdateMTU(bluetoothPeripheral, -1) }
+            }
+        }
+    }
+
+    // ---- L2CAP ----
+
+    actual fun openL2capChannel(bluetoothPeripheral: BluetoothPeripheral, psm: Int) {
+        // L2CAP CoC is not exposed via BlueZ's D-Bus API. It would require
+        // raw Linux sockets (AF_BLUETOOTH, BTPROTO_L2CAP) outside of sdbus-kotlin.
+        notifyDelegates { it.didOpenL2capChannel(bluetoothPeripheral, null) }
+    }
+
+    // ---- Bonding ----
+
+    actual fun createBond(bluetoothPeripheral: BluetoothPeripheral) {
+        val impl = bluetoothPeripheral as BluetoothPeripheralImpl
+        scope.launch {
+            try {
+                val device = connectedDevices[impl.device.objectPath]
+                    ?: throw IllegalStateException("Not connected")
+                device.proxy.pair()
+                // didBondStateChanged fires from the connectedProperty
+                // observer when the Paired property becomes true
+            } catch (e: Exception) {
+                log?.error("Pair failed: ${e.message}", e)
+                notifyDelegates {
+                    it.didBondStateChanged(bluetoothPeripheral, BlueFalconBondState.None)
+                }
+            }
+        }
+    }
+
+    actual fun removeBond(bluetoothPeripheral: BluetoothPeripheral) {
+        val impl = bluetoothPeripheral as BluetoothPeripheralImpl
+        scope.launch {
+            try {
+                adapterProxy.removeDevice(impl.device.objectPath)
+                notifyDelegates {
+                    it.didBondStateChanged(bluetoothPeripheral, BlueFalconBondState.None)
+                }
+            } catch (e: Exception) {
+                log?.error("Remove bond failed: ${e.message}", e)
+            }
+        }
+    }
+
+    // ---- Lifecycle ----
+
+    actual fun destroy() {
+        isScanning = false
+        scanJob?.cancel()
+        scanJob = null
+        connectedDevices.values.forEach { it.observationScope.cancel() }
+        connectedDevices.clear()
+        // The D-Bus event loop runs on its own thread (started by
+        // enterEventLoopAsync). leaveEventLoop() is suspend, so we kick it
+        // off asynchronously. The next BlueFalcon instance awaits this in
+        // its initJob to ensure the old event loop is fully stopped before
+        // opening a new D-Bus connection.
+        pendingShutdown = CoroutineScope(Dispatchers.IO).launch {
+            connection.leaveEventLoop()
+        }
+        scope.cancel()
+    }
+
+    // ---- Private helpers ----
+
+    private fun notifyDelegates(action: (BlueFalconDelegate) -> Unit) {
+        delegates.toList().forEach(action)
+    }
+
+    private fun createCharProxy(char: BluetoothCharacteristic) = GattCharacteristic1Proxy(
+        createProxy(connection, bluezService, char.objectPath)
+    )
+
+    private suspend fun configureDiscoveryFilter(filters: List<ServiceFilter>) {
+        val filterMap = mutableMapOf<String, Variant>(
+            "Transport" to Variant("le"),
+            "DuplicateData" to Variant(false),
+        )
+        if (filters.isNotEmpty()) {
+            val uuids = filters.flatMap { it.serviceUuids }.map { it.toString() }
+            if (uuids.isNotEmpty()) {
+                filterMap["UUIDs"] = Variant(uuids)
+            }
+        }
+        try {
+            adapterProxy.setDiscoveryFilter(filterMap)
+        } catch (e: Exception) {
+            log?.debug("setDiscoveryFilter failed (may already be set): ${e.message}")
+        }
+    }
+
+    private suspend fun startDiscovery() {
+        try {
+            adapterProxy.startDiscovery()
+        } catch (e: Exception) {
+            log?.debug("startDiscovery failed (may already be discovering): ${e.message}")
+        }
+    }
+
+    /** Reads device properties from the ObjectManager's cached state rather than
+     *  creating a Device1Proxy per device, avoiding D-Bus round-trips during scan. */
+    private fun handleDeviceFound(path: ObjectPath, properties: Map<PropertyName, Variant>) {
+        if (!path.value.startsWith(adapterPath.value)) return
+
+        val device = NativeBluetoothDevice(path)
+        val peripheral = knownPeripherals.getOrPut(path) { BluetoothPeripheralImpl(device) }
+
+        properties[PropertyName("Name")]?.let { peripheral._name = it.get<String>() }
+        properties[PropertyName("RSSI")]?.let { peripheral.rssi = it.get<Short>().toFloat() }
+
+        _peripherals.tryEmit(_peripherals.value + setOf(peripheral))
+
+        val advData = mutableMapOf<AdvertisementDataRetrievalKeys, Any>()
+        properties[PropertyName("Name")]?.let { advData[AdvertisementDataRetrievalKeys.LocalName] = it.get<String>() }
+        advData[AdvertisementDataRetrievalKeys.IsConnectable] = 1
+        notifyDelegates { it.didDiscoverDevice(peripheral, advData) }
+    }
+
+    /** Launches coroutines that observe a connected device's property changes. */
+    private fun observeDeviceProperties(
+        impl: BluetoothPeripheralImpl,
+        deviceProxy: Device1Proxy
+    ): Job = scope.launch {
+        launch {
+            deviceProxy.connectedProperty.changes().collect { connected ->
+                if (connected) {
+                    notifyDelegates { it.didConnect(impl) }
+                    if (autoDiscoverAllServicesAndCharacteristics) {
+                        launch { awaitAndResolveServices(impl, deviceProxy) }
+                    }
+                } else {
+                    notifyDelegates { it.didDisconnect(impl) }
+                }
+            }
+        }
+        launch {
+            deviceProxy.servicesResolvedProperty.changes().collect { resolved ->
+                if (resolved) {
+                    resolveGattObjects(impl)
+                    notifyDelegates { it.didDiscoverServices(impl) }
+                }
+            }
+        }
+        launch {
+            deviceProxy.pairedProperty.changes().collect { paired ->
+                notifyDelegates {
+                    it.didBondStateChanged(
+                        impl,
+                        if (paired) BlueFalconBondState.Bonded else BlueFalconBondState.None
+                    )
+                }
+            }
+        }
+        launch {
+            deviceProxy.rSSIProperty.changesOrNull().collect { rssi ->
+                rssi?.let {
+                    impl.rssi = it.toFloat()
+                    notifyDelegates { d -> d.didRssiUpdate(impl) }
+                }
+            }
+        }
+    }
+
+    private suspend fun awaitAndResolveServices(
+        peripheral: BluetoothPeripheralImpl,
+        deviceProxy: Device1Proxy
+    ) {
+        try {
+            if (deviceProxy.servicesResolved) {
+                resolveGattObjects(peripheral)
+                notifyDelegates { it.didDiscoverServices(peripheral) }
+            }
+        } catch (e: Exception) {
+            log?.error("awaitAndResolveServices failed: ${e.message}", e)
+        }
+    }
+
+    private fun resolveGattObjects(peripheral: BluetoothPeripheralImpl) {
+        try {
+            val managed = objectManagerProxy.getManagedObjects()
+            val devPrefix = peripheral.device.objectPath.value
+
+            val svcInterface = InterfaceName("org.bluez.GattService1")
+            val charInterface = InterfaceName("org.bluez.GattCharacteristic1")
+            val descInterface = InterfaceName("org.bluez.GattDescriptor1")
+
+            val services = mutableListOf<BluetoothService>()
+            val characteristics = mutableMapOf<ObjectPath, BluetoothCharacteristic>()
+
+            for ((path, interfaces) in managed) {
+                if (!path.value.startsWith("$devPrefix/")) continue
+                val svcProps = interfaces[svcInterface] ?: continue
+                val uuidStr = svcProps[PropertyName("UUID")]?.get<String>() ?: continue
+                services.add(BluetoothService(path, Uuid.parse(uuidStr)))
+            }
+
+            for ((path, interfaces) in managed) {
+                if (!path.value.startsWith("$devPrefix/")) continue
+                val charProps = interfaces[charInterface] ?: continue
+                val uuidStr = charProps[PropertyName("UUID")]?.get<String>() ?: continue
+                val svcPath = charProps[PropertyName("Service")]?.get<ObjectPath>() ?: continue
+                val char = BluetoothCharacteristic(path, Uuid.parse(uuidStr), svcPath)
+                val parent = services.find { it.objectPath == svcPath }
+                if (parent != null) {
+                    parent.addCharacteristic(char)
+                    char.setService(parent)
+                }
+                characteristics[path] = char
+            }
+
+            for ((path, interfaces) in managed) {
+                if (!path.value.startsWith("$devPrefix/")) continue
+                val descProps = interfaces[descInterface] ?: continue
+                val uuidStr = descProps[PropertyName("UUID")]?.get<String>() ?: continue
+                val charPath = descProps[PropertyName("Characteristic")]?.get<ObjectPath>() ?: continue
+                val desc = BluetoothCharacteristicDescriptor(path, Uuid.parse(uuidStr), charPath)
+                characteristics[charPath]?.addDescriptor(desc)
+            }
+
+            peripheral._servicesFlow.tryEmit(services)
+        } catch (e: Exception) {
+            log?.error("resolveGattObjects failed: ${e.message}", e)
+        }
+    }
+
+    companion object {
+        private var pendingShutdown: Job? = null
+    }
+}

--- a/library/src/linuxMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.linux.kt
+++ b/library/src/linuxMain/kotlin/dev/bluefalcon/BluetoothCharacteristic.linux.kt
@@ -1,0 +1,71 @@
+package dev.bluefalcon
+
+import com.monkopedia.sdbus.ObjectPath
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+
+actual class BluetoothCharacteristic(
+    val objectPath: ObjectPath,
+    actual val uuid: Uuid,
+    private val serviceObjectPath: ObjectPath,
+) {
+    actual val name: String?
+        get() = uuid.toString()
+
+    internal var _value: ByteArray? = null
+    actual val value: ByteArray?
+        get() = _value
+
+    private val _descriptors = mutableListOf<BluetoothCharacteristicDescriptor>()
+    actual val descriptors: List<BluetoothCharacteristicDescriptor>
+        get() = _descriptors
+
+    internal var _isNotifying: Boolean = false
+    internal var _notifyJob: Job? = null
+    actual val isNotifying: Boolean
+        get() = _isNotifying
+
+    private var _service: BluetoothService? = null
+    actual val service: BluetoothService?
+        get() = _service
+
+    internal actual val _descriptorsFlow = MutableStateFlow<List<BluetoothCharacteristicDescriptor>>(emptyList())
+
+    internal fun setService(service: BluetoothService) {
+        _service = service
+    }
+
+    internal fun addDescriptor(descriptor: BluetoothCharacteristicDescriptor) {
+        if (_descriptors.none { it.uuid == descriptor.uuid }) {
+            _descriptors.add(descriptor)
+            _descriptorsFlow.tryEmit(_descriptors.toList())
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BluetoothCharacteristic) return false
+        return objectPath == other.objectPath
+    }
+
+    override fun hashCode(): Int = objectPath.hashCode()
+}
+
+actual class BluetoothCharacteristicDescriptor(
+    val objectPath: ObjectPath,
+    val uuid: Uuid,
+    val characteristicObjectPath: ObjectPath,
+) {
+    internal var _value: ByteArray? = null
+    var value: ByteArray?
+        get() = _value
+        set(v) { _value = v }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BluetoothCharacteristicDescriptor) return false
+        return objectPath == other.objectPath
+    }
+
+    override fun hashCode(): Int = objectPath.hashCode()
+}

--- a/library/src/linuxMain/kotlin/dev/bluefalcon/BluetoothPeripheral.linux.kt
+++ b/library/src/linuxMain/kotlin/dev/bluefalcon/BluetoothPeripheral.linux.kt
@@ -1,0 +1,55 @@
+package dev.bluefalcon
+
+import com.monkopedia.sdbus.ObjectPath
+import kotlinx.coroutines.flow.MutableStateFlow
+
+actual class NativeBluetoothDevice(val objectPath: ObjectPath) {
+    val address: String
+        get() {
+            // Path is like /org/bluez/hci0/dev_40_4C_CA_42_4F_EA
+            val devPart = objectPath.value.substringAfterLast("/dev_", "")
+            return devPart.replace("_", ":").ifEmpty { objectPath.value }
+        }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is NativeBluetoothDevice) return false
+        return objectPath == other.objectPath
+    }
+
+    override fun hashCode(): Int = objectPath.hashCode()
+    override fun toString(): String = address
+}
+
+actual class BluetoothPeripheralImpl actual constructor(
+    actual override val device: NativeBluetoothDevice
+) : BluetoothPeripheral {
+
+    internal var _name: String? = null
+
+    actual override val name: String?
+        get() = _name ?: device.address
+
+    actual override val uuid: String
+        get() = device.address
+
+    actual override var rssi: Float? = null
+    actual override var mtuSize: Int? = null
+
+    actual override val _servicesFlow = MutableStateFlow<List<BluetoothService>>(emptyList())
+
+    actual override val services: Map<Uuid, BluetoothService>
+        get() = _servicesFlow.value.associateBy { it.uuid }
+
+    actual override val characteristics: Map<Uuid, List<BluetoothCharacteristic>>
+        get() = services.values
+            .flatMap { it.characteristics }
+            .groupBy { it.uuid }
+
+    override fun toString(): String = uuid
+    override fun hashCode(): Int = uuid.hashCode()
+    override fun equals(other: Any?): Boolean {
+        if (other == null || other !is BluetoothPeripheralImpl) return false
+        return other.uuid == uuid
+    }
+}

--- a/library/src/linuxMain/kotlin/dev/bluefalcon/BluetoothService.linux.kt
+++ b/library/src/linuxMain/kotlin/dev/bluefalcon/BluetoothService.linux.kt
@@ -1,0 +1,26 @@
+package dev.bluefalcon
+
+import com.monkopedia.sdbus.ObjectPath
+import kotlinx.coroutines.flow.MutableStateFlow
+
+actual class BluetoothService(
+    val objectPath: ObjectPath,
+    actual val uuid: Uuid,
+) {
+    actual val name: String?
+        get() = uuid.toString()
+
+    private val _characteristics = mutableListOf<BluetoothCharacteristic>()
+
+    actual val characteristics: List<BluetoothCharacteristic>
+        get() = _characteristics
+
+    internal actual val _characteristicsFlow = MutableStateFlow<List<BluetoothCharacteristic>>(emptyList())
+
+    internal fun addCharacteristic(characteristic: BluetoothCharacteristic) {
+        if (_characteristics.none { it.uuid == characteristic.uuid }) {
+            _characteristics.add(characteristic)
+            _characteristicsFlow.tryEmit(_characteristics.toList())
+        }
+    }
+}

--- a/library/src/linuxMain/kotlin/dev/bluefalcon/ConnectionPriority.linux.kt
+++ b/library/src/linuxMain/kotlin/dev/bluefalcon/ConnectionPriority.linux.kt
@@ -1,0 +1,7 @@
+package dev.bluefalcon
+
+actual fun ConnectionPriority.toNative(): Int = when (this) {
+    ConnectionPriority.Balanced -> 0
+    ConnectionPriority.High -> 1
+    ConnectionPriority.Low -> 2
+}

--- a/library/src/linuxMain/kotlin/dev/bluefalcon/NoInputNoOutputAgent.kt
+++ b/library/src/linuxMain/kotlin/dev/bluefalcon/NoInputNoOutputAgent.kt
@@ -1,0 +1,21 @@
+package dev.bluefalcon
+
+import com.monkopedia.sdbus.Object
+import com.monkopedia.sdbus.ObjectPath
+import dev.bluefalcon.bluez.Agent1Adaptor
+
+/**
+ * A BlueZ Agent1 implementation that auto-accepts all pairing requests.
+ * Uses NoInputNoOutput capability for Just Works pairing.
+ */
+class NoInputNoOutputAgent(obj: Object) : Agent1Adaptor(obj) {
+    override suspend fun release() {}
+    override suspend fun requestPinCode(device: ObjectPath): String = "0000"
+    override suspend fun displayPinCode(device: ObjectPath, pincode: String) {}
+    override suspend fun requestPasskey(device: ObjectPath): UInt = 0u
+    override suspend fun displayPasskey(device: ObjectPath, passkey: UInt, entered: UShort) {}
+    override suspend fun requestConfirmation(device: ObjectPath, passkey: UInt) {}
+    override suspend fun requestAuthorization(device: ObjectPath) {}
+    override suspend fun authorizeService(device: ObjectPath, uuid: String) {}
+    override suspend fun cancel() {}
+}

--- a/library/src/linuxMain/kotlin/dev/bluefalcon/ServiceFilter.linux.kt
+++ b/library/src/linuxMain/kotlin/dev/bluefalcon/ServiceFilter.linux.kt
@@ -1,0 +1,5 @@
+package dev.bluefalcon
+
+actual data class ServiceFilter(
+    val serviceUuids: List<Uuid> = emptyList(),
+)

--- a/library/src/linuxMain/kotlin/dev/bluefalcon/Uuid.linux.kt
+++ b/library/src/linuxMain/kotlin/dev/bluefalcon/Uuid.linux.kt
@@ -1,0 +1,5 @@
+package dev.bluefalcon
+
+import kotlin.uuid.Uuid
+
+actual typealias Uuid = Uuid


### PR DESCRIPTION
Closes #198

## Summary

Adds Kotlin/Native Linux targets (`linuxX64`, `linuxArm64`) that wrap BlueZ's D-Bus API via [sdbus-kotlin](https://github.com/Monkopedia/sdbus-kotlin). The implementation lives entirely in a `linuxMain` source set and doesn't touch any existing platform code.

Disclosure: I'm the author of sdbus-kotlin.

## What's included

**Build changes:**
- `linuxX64()` and `linuxArm64()` targets
- [sdbus-kotlin](https://github.com/Monkopedia/sdbus-kotlin) plugin (0.4.2) for D-Bus proxy/adaptor code generation
- `kotlinx-serialization` plugin (required by generated code)
- `linuxMain` source set depending on `com.monkopedia:sdbus-kotlin:0.4.2`

**D-Bus interface definitions** (`library/src/dbusMain/`):
9 XML introspection files for BlueZ interfaces — Adapter1, Device1, GattService1, GattCharacteristic1, GattDescriptor1, Agent1, AgentManager1, ObjectManager, Properties. The sdbus-kotlin plugin generates typed Kotlin proxies and adaptors from these at build time. (This is an sdbus plugin input directory, not a Kotlin source set.)

**Linux implementation** (`library/src/linuxMain/`):
- `BlueFalcon` — full API implementation using generated proxies
  - Scan via `ObjectManagerProxy.objectsFor()` reactive flow (no polling)
  - Connect/disconnect via `Device1Proxy` with typed property flows (`connectedProperty.changes()`, `pairedProperty.changes()`, etc.)
  - GATT read/write/notify via generated characteristic proxies
  - Notifications via `charProxy.valueProperty.changes()` flow
  - Pairing via `NoInputNoOutputAgent` (generated `Agent1Adaptor` subclass)
  - Safe re-initialisation: each new `BlueFalcon` instance waits for the previous instance's D-Bus event loop to stop before opening a new connection
  - `ApplicationContext` carries optional `CoroutineScope` for DI
  - No `runBlocking` in library code
- Model classes wrapping D-Bus object paths
- Type aliases: `Uuid = kotlin.uuid.Uuid`, `ApplicationContext` with configurable scope

**API coverage:**

| Status | APIs |
|--------|------|
| ✅ Implemented | scan, connect, disconnect, connectionState, discoverServices, discoverCharacteristics, readCharacteristic, writeCharacteristic, writeCharacteristicWithoutEncoding, notifyCharacteristic, indicateCharacteristic, notifyAndIndicateCharacteristic, readDescriptor, writeDescriptor, createBond, removeBond, retrievePeripheral, clearPeripherals, destroy |
| ⚠️ Partial | changeMTU — reads the negotiated MTU from BlueZ but cannot request a specific value (BlueZ negotiates automatically at the kernel level; the `mtuSize` parameter is not used) |
| ⬜ Stubbed | openL2capChannel — not available via BlueZ D-Bus API ([socket-only](https://github.com/bluez/bluez/wiki/L2CAP)); returns null via didOpenL2capChannel |
| ⬜ Stubbed | requestConnectionPriority — no BlueZ D-Bus equivalent ([rejected upstream](https://github.com/bluez/bluez/issues/910)); silent no-op |

## Build requirements

- **Build time:** `libsystemd-dev` (for sdbus-kotlin's D-Bus binding)
- **Runtime:** `libsystemd` (system D-Bus transport)
- **BlueZ:** 5.50+ recommended (tested on 5.86)

These dependencies are confined to the Linux source set — no impact on Android, iOS, macOS, Windows, or JS builds.

## Testing

Tested against a dedicated ESP32-C6 BLE test peripheral ([bf-test-peripheral](https://github.com/Monkopedia/bf-test-peripheral)) that exposes a GATT profile covering the full API surface.

Integration test suite (16 tests) validated on:
- **Android** (Pixel 6 Pro, Pixel 2 XL)
- **Linux** (BlueZ 5.86, x86_64)

Test source: [`integration-tests-clean` branch](https://github.com/Monkopedia/blue-falcon/tree/integration-tests-clean/integration-tests)

Tests cover: scan, connect, disconnect, service/characteristic discovery, read, write, write-no-response, notifications, indications, notify+indicate, descriptors, MTU, bonding with encrypted characteristic read.

## Dependencies

- [sdbus-kotlin](https://github.com/Monkopedia/sdbus-kotlin) 0.4.2 (Apache-2.0) — Kotlin/Native D-Bus binding
- `libsystemd` (LGPL-2.1, runtime, Linux only) — system D-Bus transport