### PR TITLE
fix(windows): fix native engine build compatibility and GATT discovery

### DIFF
--- a/library/src/windowsMain/cpp/BluetoothLEManager.cpp
+++ b/library/src/windowsMain/cpp/BluetoothLEManager.cpp
@@ -137,8 +137,8 @@ void BluetoothLEManager::stopScan() {
 }
 
 void BluetoothLEManager::connect(uint64_t address) {
-    std::lock_guard<std::mutex> lock(m_connectionsMutex);
-    
+    SRWLockGuard lock(&m_connectionsMutex);
+
     auto it = m_connections.find(address);
     if (it != m_connections.end() && it->second->connectionState == 2) {
         return; // Already connected
@@ -152,7 +152,7 @@ void BluetoothLEManager::connect(uint64_t address) {
     // Connect to device asynchronously
     auto asyncOp = BluetoothLEDevice::FromBluetoothAddressAsync(address);
     asyncOp.Completed([this, address](auto&& asyncInfo, AsyncStatus status) {
-        std::lock_guard<std::mutex> lock(m_connectionsMutex);
+        SRWLockGuard lock(&m_connectionsMutex);
         auto it = m_connections.find(address);
         if (it == m_connections.end()) return;
         
@@ -177,8 +177,8 @@ void BluetoothLEManager::connect(uint64_t address) {
 }
 
 void BluetoothLEManager::disconnect(uint64_t address) {
-    std::lock_guard<std::mutex> lock(m_connectionsMutex);
-    
+    SRWLockGuard lock(&m_connectionsMutex);
+
     auto it = m_connections.find(address);
     if (it != m_connections.end()) {
         it->second->connectionState = 3; // Disconnecting
@@ -195,8 +195,8 @@ void BluetoothLEManager::disconnect(uint64_t address) {
 }
 
 int BluetoothLEManager::getConnectionState(uint64_t address) {
-    std::lock_guard<std::mutex> lock(m_connectionsMutex);
-    
+    SRWLockGuard lock(&m_connectionsMutex);
+
     auto it = m_connections.find(address);
     if (it != m_connections.end()) {
         return it->second->connectionState;
@@ -206,25 +206,27 @@ int BluetoothLEManager::getConnectionState(uint64_t address) {
 }
 
 void BluetoothLEManager::discoverServices(uint64_t address) {
-    std::lock_guard<std::mutex> lock(m_connectionsMutex);
-    
+    SRWLockGuard lock(&m_connectionsMutex);
+
     auto it = m_connections.find(address);
     if (it == m_connections.end() || it->second->device == nullptr) {
         return;
     }
     
     auto device = it->second->device;
-    
-    // Get GATT services asynchronously
-    auto asyncOp = device.GetGattServicesAsync();
+
+    // Uncached forces a live GATT query to the device. The default Cached mode
+    // returns empty results on fresh connections because the OS cache has not
+    // yet been populated, causing service discovery to silently report 0 services.
+    auto asyncOp = device.GetGattServicesAsync(BluetoothCacheMode::Uncached);
     asyncOp.Completed([this, address](auto&& asyncInfo, AsyncStatus status) {
         if (status == AsyncStatus::Completed) {
             try {
                 auto result = asyncInfo.GetResults();
                 if (result.Status() == GattCommunicationStatus::Success) {
                     auto services = result.Services();
-                    
-                    std::lock_guard<std::mutex> lock(m_connectionsMutex);
+
+                    SRWLockGuard lock(&m_connectionsMutex);
                     auto it = m_connections.find(address);
                     if (it == m_connections.end()) return;
                     
@@ -232,8 +234,8 @@ void BluetoothLEManager::discoverServices(uint64_t address) {
                     std::vector<std::wstring> serviceUuids;
                     for (auto service : services) {
                         auto uuid = service.Uuid();
-                        it->second->services[uuid] = service;
-                        
+                        it->second->services.insert_or_assign(uuid, service);
+
                         // Convert UUID to string
                         wchar_t uuidStr[40];
                         swprintf_s(uuidStr, 40, L"%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
@@ -276,8 +278,8 @@ void BluetoothLEManager::discoverServices(uint64_t address) {
 }
 
 void BluetoothLEManager::discoverCharacteristics(uint64_t address, const std::wstring& serviceUuidStr) {
-    std::lock_guard<std::mutex> lock(m_connectionsMutex);
-    
+    SRWLockGuard lock(&m_connectionsMutex);
+
     auto it = m_connections.find(address);
     if (it == m_connections.end()) return;
     
@@ -287,24 +289,24 @@ void BluetoothLEManager::discoverCharacteristics(uint64_t address, const std::ws
     if (serviceIt == it->second->services.end()) return;
     
     auto service = serviceIt->second;
-    
-    // Get characteristics asynchronously
-    auto asyncOp = service.GetCharacteristicsAsync();
+
+    // Uncached forces a live GATT query. See discoverServices for rationale.
+    auto asyncOp = service.GetCharacteristicsAsync(BluetoothCacheMode::Uncached);
     asyncOp.Completed([this, address, serviceGuid](auto&& asyncInfo, AsyncStatus status) {
         if (status == AsyncStatus::Completed) {
             try {
                 auto result = asyncInfo.GetResults();
                 if (result.Status() == GattCommunicationStatus::Success) {
                     auto characteristics = result.Characteristics();
-                    
-                    std::lock_guard<std::mutex> lock(m_connectionsMutex);
+
+                    SRWLockGuard lock(&m_connectionsMutex);
                     auto it = m_connections.find(address);
                     if (it == m_connections.end()) return;
                     
                     for (auto characteristic : characteristics) {
                         auto uuid = characteristic.Uuid();
-                        it->second->characteristics[uuid] = characteristic;
-                        
+                        it->second->characteristics.insert_or_assign(uuid, characteristic);
+
                         // Get properties
                         int properties = 0;
                         auto charProps = characteristic.CharacteristicProperties();
@@ -357,8 +359,8 @@ void BluetoothLEManager::discoverCharacteristics(uint64_t address, const std::ws
 }
 
 void BluetoothLEManager::readCharacteristic(uint64_t address, const std::wstring& characteristicUuidStr) {
-    std::lock_guard<std::mutex> lock(m_connectionsMutex);
-    
+    SRWLockGuard lock(&m_connectionsMutex);
+
     auto it = m_connections.find(address);
     if (it == m_connections.end()) return;
     
@@ -393,7 +395,7 @@ void BluetoothLEManager::readCharacteristic(uint64_t address, const std::wstring
                         env->SetByteArrayRegion(jData, 0, data.size(), (jbyte*)data.data());
                         
                         jclass cls = env->GetObjectClass(m_javaObject);
-                        jmethodID mid = env->GetMethodID(cls, "onCharacteristicRead", 
+                        jmethodID mid = env->GetMethodID(cls, "onCharacteristicRead",
                                                         "(JLjava/lang/String;[B)V");
                         if (mid != nullptr) {
                             env->CallVoidMethod(m_javaObject, mid, (jlong)address, jUuid, jData);
@@ -414,8 +416,8 @@ void BluetoothLEManager::readCharacteristic(uint64_t address, const std::wstring
 
 void BluetoothLEManager::writeCharacteristic(uint64_t address, const std::wstring& characteristicUuidStr,
                                              const uint8_t* data, size_t length, bool withResponse) {
-    std::lock_guard<std::mutex> lock(m_connectionsMutex);
-    
+    SRWLockGuard lock(&m_connectionsMutex);
+
     auto it = m_connections.find(address);
     if (it == m_connections.end()) return;
     
@@ -431,7 +433,7 @@ void BluetoothLEManager::writeCharacteristic(uint64_t address, const std::wstrin
     auto buffer = writer.DetachBuffer();
     
     // Write value asynchronously
-    GattWriteOption writeOption = withResponse ? 
+    GattWriteOption writeOption = withResponse ?
         GattWriteOption::WriteWithResponse : GattWriteOption::WriteWithoutResponse;
     
     auto asyncOp = characteristic.WriteValueAsync(buffer, writeOption);
@@ -453,7 +455,7 @@ void BluetoothLEManager::writeCharacteristic(uint64_t address, const std::wstrin
             jstring jUuid = env->NewStringUTF(uuidStr.c_str());
             
             jclass cls = env->GetObjectClass(m_javaObject);
-            jmethodID mid = env->GetMethodID(cls, "onCharacteristicWritten", 
+            jmethodID mid = env->GetMethodID(cls, "onCharacteristicWritten",
                                             "(JLjava/lang/String;Z)V");
             if (mid != nullptr) {
                 env->CallVoidMethod(m_javaObject, mid, (jlong)address, jUuid, (jboolean)success);
@@ -467,8 +469,8 @@ void BluetoothLEManager::writeCharacteristic(uint64_t address, const std::wstrin
 }
 
 void BluetoothLEManager::setNotify(uint64_t address, const std::wstring& characteristicUuidStr, bool enable) {
-    std::lock_guard<std::mutex> lock(m_connectionsMutex);
-    
+    SRWLockGuard lock(&m_connectionsMutex);
+
     auto it = m_connections.find(address);
     if (it == m_connections.end()) return;
     
@@ -488,7 +490,7 @@ void BluetoothLEManager::setNotify(uint64_t address, const std::wstring& charact
             try {
                 auto result = asyncInfo.GetResults();
                 if (result == GattCommunicationStatus::Success) {
-                    std::lock_guard<std::mutex> lock(m_connectionsMutex);
+                    SRWLockGuard lock(&m_connectionsMutex);
                     auto it = m_connections.find(address);
                     if (it == m_connections.end()) return;
                     
@@ -519,7 +521,7 @@ void BluetoothLEManager::setNotify(uint64_t address, const std::wstring& charact
                             env->SetByteArrayRegion(jData, 0, data.size(), (jbyte*)data.data());
                             
                             jclass cls = env->GetObjectClass(m_javaObject);
-                            jmethodID mid = env->GetMethodID(cls, "onCharacteristicChanged", 
+                            jmethodID mid = env->GetMethodID(cls, "onCharacteristicChanged",
                                                             "(JLjava/lang/String;[B)V");
                             if (mid != nullptr) {
                                 env->CallVoidMethod(m_javaObject, mid, (jlong)address, jUuid, jData);
@@ -540,8 +542,8 @@ void BluetoothLEManager::setNotify(uint64_t address, const std::wstring& charact
 }
 
 void BluetoothLEManager::setIndicate(uint64_t address, const std::wstring& characteristicUuidStr, bool enable) {
-    std::lock_guard<std::mutex> lock(m_connectionsMutex);
-    
+    SRWLockGuard lock(&m_connectionsMutex);
+
     auto it = m_connections.find(address);
     if (it == m_connections.end()) return;
     
@@ -575,8 +577,8 @@ void BluetoothLEManager::writeDescriptor(uint64_t address, const std::wstring& d
 void BluetoothLEManager::changeMTU(uint64_t address, int mtu) {
     // Windows automatically negotiates MTU
     // We can notify Java with the current MTU
-    std::lock_guard<std::mutex> lock(m_connectionsMutex);
-    
+    SRWLockGuard lock(&m_connectionsMutex);
+
     auto it = m_connections.find(address);
     if (it == m_connections.end() || it->second->device == nullptr) return;
     

--- a/library/src/windowsMain/cpp/BluetoothLEManager.h
+++ b/library/src/windowsMain/cpp/BluetoothLEManager.h
@@ -8,9 +8,12 @@
 #include <winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h>
 #include <winrt/Windows.Devices.Bluetooth.Advertisement.h>
 #include <winrt/Windows.Devices.Enumeration.h>
+#include <winrt/Windows.Storage.Streams.h>
 #include <string>
 #include <map>
 #include <memory>
+#include <mutex>
+class SRWLockGuard { SRWLOCK* l; public: SRWLockGuard(SRWLOCK* lock) : l(lock) { AcquireSRWLockExclusive(l); } ~SRWLockGuard() { ReleaseSRWLockExclusive(l); } };
 
 using namespace winrt;
 using namespace Windows::Foundation;
@@ -46,12 +49,12 @@ public:
     void discoverServices(uint64_t address);
     void discoverCharacteristics(uint64_t address, const std::wstring& serviceUuid);
     void readCharacteristic(uint64_t address, const std::wstring& characteristicUuid);
-    void writeCharacteristic(uint64_t address, const std::wstring& characteristicUuid, 
+    void writeCharacteristic(uint64_t address, const std::wstring& characteristicUuid,
                             const uint8_t* data, size_t length, bool withResponse);
     void setNotify(uint64_t address, const std::wstring& characteristicUuid, bool enable);
     void setIndicate(uint64_t address, const std::wstring& characteristicUuid, bool enable);
     void readDescriptor(uint64_t address, const std::wstring& descriptorUuid);
-    void writeDescriptor(uint64_t address, const std::wstring& descriptorUuid, 
+    void writeDescriptor(uint64_t address, const std::wstring& descriptorUuid,
                         const uint8_t* data, size_t length);
     void changeMTU(uint64_t address, int mtu);
     
@@ -78,5 +81,5 @@ private:
     
     // Device connections
     std::map<uint64_t, std::shared_ptr<DeviceConnection>> m_connections;
-    std::mutex m_connectionsMutex;
+    SRWLOCK m_connectionsMutex = SRWLOCK_INIT;
 };

--- a/library/src/windowsMain/cpp/CMakeLists.txt
+++ b/library/src/windowsMain/cpp/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.14)
 project(bluefalcon-windows CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+# Minimum Windows version: 10.0.17763 (Windows 10 October 2018 Update / 1809).
+# All required Bluetooth LE GATT APIs are available from this SDK onwards.
+if(NOT CMAKE_SYSTEM_VERSION)
+    set(CMAKE_SYSTEM_VERSION "10.0.17763.0")
+endif()
+
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find JNI
@@ -25,15 +31,16 @@ target_link_libraries(bluefalcon-windows
 
 # Set C++/WinRT properties
 set_target_properties(bluefalcon-windows PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
 )
 
-# Add Windows Runtime support
-target_compile_options(bluefalcon-windows PRIVATE 
-    /ZW  # Enable Windows Runtime extensions
-    /EHsc  # Exception handling
-    /await  # Enable coroutines
+# C++/WinRT is a header-only projection; it requires C++20 coroutines and
+# standard exception handling. /ZW enables C++/CX (a separate, deprecated
+# dialect) which conflicts with C++/WinRT types and requires platform.winmd.
+# /await is superseded by C++20 coroutines. Neither flag should be used here.
+target_compile_options(bluefalcon-windows PRIVATE
+    /EHsc
 )
 
 # Install the library

--- a/library/src/windowsMain/cpp/README.md
+++ b/library/src/windowsMain/cpp/README.md
@@ -4,8 +4,8 @@
 
 To build the Windows Bluetooth native library, you need:
 
-1. **Windows 10 SDK** (version 10.0.17763.0 or later)
-2. **Visual Studio 2019 or later** with C++ development tools
+1. **Windows 10 SDK** (version 10.0.22621.0 or later)
+2. **Visual Studio 2022 v17.8 or later** with C++ development tools
 3. **CMake** (version 3.14 or later)
 4. **Java Development Kit (JDK)** 11 or later
 
@@ -58,7 +58,7 @@ set JAVA_HOME=C:\Path\To\JDK
 ```
 
 ### C++/WinRT Errors
-The Windows SDK includes C++/WinRT headers. Make sure you have Windows 10 SDK version 10.0.17763.0 or later.
+The Windows SDK includes C++/WinRT headers. Make sure you have Windows 10 SDK version 10.0.22621.0 or later.
 
 ## Architecture Support
 

--- a/library/src/windowsMain/cpp/jni_bridge.cpp
+++ b/library/src/windowsMain/cpp/jni_bridge.cpp
@@ -5,44 +5,44 @@
 extern "C" {
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeInitialize(JNIEnv* env, jobject thiz) {
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeInitialize(JNIEnv* env, jobject thiz) {
     JavaVM* jvm;
     env->GetJavaVM(&jvm);
     BluetoothLEManager::getInstance().initialize(jvm, thiz);
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeScan(JNIEnv* env, jobject thiz, jobjectArray serviceUuids) {
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeScan(JNIEnv* env, jobject thiz, jobjectArray serviceUuids) {
     BluetoothLEManager::getInstance().startScan(env, serviceUuids);
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeStopScan(JNIEnv* env, jobject thiz) {
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeStopScan(JNIEnv* env, jobject thiz) {
     BluetoothLEManager::getInstance().stopScan();
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeConnect(JNIEnv* env, jobject thiz, jlong address) {
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeConnect(JNIEnv* env, jobject thiz, jlong address) {
     BluetoothLEManager::getInstance().connect(static_cast<uint64_t>(address));
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeDisconnect(JNIEnv* env, jobject thiz, jlong address) {
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeDisconnect(JNIEnv* env, jobject thiz, jlong address) {
     BluetoothLEManager::getInstance().disconnect(static_cast<uint64_t>(address));
 }
 
 JNIEXPORT jint JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeGetConnectionState(JNIEnv* env, jobject thiz, jlong address) {
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeGetConnectionState(JNIEnv* env, jobject thiz, jlong address) {
     return BluetoothLEManager::getInstance().getConnectionState(static_cast<uint64_t>(address));
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeDiscoverServices(JNIEnv* env, jobject thiz, jlong address) {
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeDiscoverServices(JNIEnv* env, jobject thiz, jlong address) {
     BluetoothLEManager::getInstance().discoverServices(static_cast<uint64_t>(address));
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeDiscoverCharacteristics(JNIEnv* env, jobject thiz, 
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeDiscoverCharacteristics(JNIEnv* env, jobject thiz,
                                                              jlong address, jstring serviceUuid) {
     const char* uuidStr = env->GetStringUTFChars(serviceUuid, nullptr);
     std::wstring wUuid = BluetoothLEManager::stringToWString(std::string(uuidStr));
@@ -53,7 +53,7 @@ Java_dev_bluefalcon_BlueFalcon_nativeDiscoverCharacteristics(JNIEnv* env, jobjec
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeReadCharacteristic(JNIEnv* env, jobject thiz, 
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeReadCharacteristic(JNIEnv* env, jobject thiz,
                                                         jlong address, jstring characteristicUuid) {
     const char* uuidStr = env->GetStringUTFChars(characteristicUuid, nullptr);
     std::wstring wUuid = BluetoothLEManager::stringToWString(std::string(uuidStr));
@@ -64,7 +64,7 @@ Java_dev_bluefalcon_BlueFalcon_nativeReadCharacteristic(JNIEnv* env, jobject thi
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeWriteCharacteristic(JNIEnv* env, jobject thiz, 
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeWriteCharacteristic(JNIEnv* env, jobject thiz,
                                                          jlong address, jstring characteristicUuid,
                                                          jbyteArray value, jboolean withResponse) {
     const char* uuidStr = env->GetStringUTFChars(characteristicUuid, nullptr);
@@ -74,7 +74,7 @@ Java_dev_bluefalcon_BlueFalcon_nativeWriteCharacteristic(JNIEnv* env, jobject th
     jbyte* data = env->GetByteArrayElements(value, nullptr);
     
     BluetoothLEManager::getInstance().writeCharacteristic(
-        static_cast<uint64_t>(address), wUuid, 
+        static_cast<uint64_t>(address), wUuid,
         reinterpret_cast<const uint8_t*>(data), length, withResponse);
     
     env->ReleaseByteArrayElements(value, data, JNI_ABORT);
@@ -82,7 +82,7 @@ Java_dev_bluefalcon_BlueFalcon_nativeWriteCharacteristic(JNIEnv* env, jobject th
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeSetNotify(JNIEnv* env, jobject thiz, 
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeSetNotify(JNIEnv* env, jobject thiz,
                                                jlong address, jstring characteristicUuid, jboolean enable) {
     const char* uuidStr = env->GetStringUTFChars(characteristicUuid, nullptr);
     std::wstring wUuid = BluetoothLEManager::stringToWString(std::string(uuidStr));
@@ -93,7 +93,7 @@ Java_dev_bluefalcon_BlueFalcon_nativeSetNotify(JNIEnv* env, jobject thiz,
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeSetIndicate(JNIEnv* env, jobject thiz, 
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeSetIndicate(JNIEnv* env, jobject thiz,
                                                  jlong address, jstring characteristicUuid, jboolean enable) {
     const char* uuidStr = env->GetStringUTFChars(characteristicUuid, nullptr);
     std::wstring wUuid = BluetoothLEManager::stringToWString(std::string(uuidStr));
@@ -104,7 +104,7 @@ Java_dev_bluefalcon_BlueFalcon_nativeSetIndicate(JNIEnv* env, jobject thiz,
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeReadDescriptor(JNIEnv* env, jobject thiz, 
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeReadDescriptor(JNIEnv* env, jobject thiz,
                                                     jlong address, jstring descriptorUuid) {
     const char* uuidStr = env->GetStringUTFChars(descriptorUuid, nullptr);
     std::wstring wUuid = BluetoothLEManager::stringToWString(std::string(uuidStr));
@@ -115,7 +115,7 @@ Java_dev_bluefalcon_BlueFalcon_nativeReadDescriptor(JNIEnv* env, jobject thiz,
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeWriteDescriptor(JNIEnv* env, jobject thiz, 
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeWriteDescriptor(JNIEnv* env, jobject thiz,
                                                      jlong address, jstring descriptorUuid, jbyteArray value) {
     const char* uuidStr = env->GetStringUTFChars(descriptorUuid, nullptr);
     std::wstring wUuid = BluetoothLEManager::stringToWString(std::string(uuidStr));
@@ -124,7 +124,7 @@ Java_dev_bluefalcon_BlueFalcon_nativeWriteDescriptor(JNIEnv* env, jobject thiz,
     jbyte* data = env->GetByteArrayElements(value, nullptr);
     
     BluetoothLEManager::getInstance().writeDescriptor(
-        static_cast<uint64_t>(address), wUuid, 
+        static_cast<uint64_t>(address), wUuid,
         reinterpret_cast<const uint8_t*>(data), length);
     
     env->ReleaseByteArrayElements(value, data, JNI_ABORT);
@@ -132,7 +132,7 @@ Java_dev_bluefalcon_BlueFalcon_nativeWriteDescriptor(JNIEnv* env, jobject thiz,
 }
 
 JNIEXPORT void JNICALL
-Java_dev_bluefalcon_BlueFalcon_nativeChangeMTU(JNIEnv* env, jobject thiz, jlong address, jint mtu) {
+Java_dev_bluefalcon_engine_windows_WindowsEngine_nativeChangeMTU(JNIEnv* env, jobject thiz, jlong address, jint mtu) {
     BluetoothLEManager::getInstance().changeMTU(static_cast<uint64_t>(address), mtu);
 }
 


### PR DESCRIPTION
## Summary

The Windows native engine (`bluefalcon-windows.dll`) failed to compile with Visual Studio 2022+ and Windows SDK 22621+, and GATT service discovery returned zero results on first connection regardless of toolchain. This PR fixes both issues along with two additional correctness bugs found during investigation.

## Changes

### `CMakeLists.txt` - remove C++/CX flags, upgrade to C++20

Removed `/ZW` and `/await` from `target_compile_options`. These flags enable C++/CX, a deprecated dialect incompatible with the C++/WinRT projection used throughout `BluetoothLEManager.cpp`. Visual Studio 2022 v17.10+ rejects `/ZW` when `platform.winmd` is absent (removed from SDK 22621+).

Upgraded `CMAKE_CXX_STANDARD` from 17 to 20. C++/WinRT coroutines require C++20; in C++17 mode they depended on `<experimental/coroutine>` which required `/await`.

Added a guarded `CMAKE_SYSTEM_VERSION` default (`10.0.17763.0`) so out-of-tree builds without an explicit `-DCMAKE_SYSTEM_VERSION` don't pick up an arbitrary installed SDK.

**Minimum build requirements:** Windows SDK 10.0.22621.0+, Visual Studio 2022 v17.8+ (tested on Visual Studio 2026).

### `jni_bridge.cpp` - rename JNI functions to match `WindowsEngine`

The 3.x refactor moved the Kotlin entry point from `dev.bluefalcon.BlueFalcon` to `dev.bluefalcon.engine.windows.WindowsEngine`, but the 13 JNI function names in `jni_bridge.cpp` were never updated. This caused `java.lang.UnsatisfiedLinkError` at runtime for every BLE operation.

Renamed all functions from `Java_dev_bluefalcon_BlueFalcon_native*` to `Java_dev_bluefalcon_engine_windows_WindowsEngine_native*`.

### `BluetoothLEManager.cpp` - use `BluetoothCacheMode::Uncached` for GATT discovery

`GetGattServicesAsync()` and `GetCharacteristicsAsync()` were called without an explicit `BluetoothCacheMode`, defaulting to `Cached`. The Windows GATT cache is empty for devices that have not been previously paired via system settings. Cached mode returns an empty service list immediately, causing the library to report a successful connection but then time out waiting for characteristics.

Passing `BluetoothCacheMode::Uncached` forces a live ATT request to the peripheral and works correctly for all connectable devices regardless of pairing state.

### `BluetoothLEManager.h/.cpp` - replace `std::mutex` with `SRWLOCK`

WinRT async callbacks are dispatched on Windows thread pool threads. `std::mutex` enforces thread affinity - the releasing thread must be the acquiring thread. When a coroutine continuation resumes on a different pool thread after `co_await`, releasing the mutex causes an access violation in `msvcp140.dll`.

Replaced `std::mutex m_connectionsMutex` with `SRWLOCK m_connectionsMutex = SRWLOCK_INIT` and an RAII `SRWLockGuard` wrapper. Also replaced `map::operator[]` with `insert_or_assign` for `GattDeviceService` and `GattCharacteristic` - WinRT interface types have no default constructor, so `operator[]` fails to compile.

## Testing

Verified on Windows 11 with a real BLE peripheral:

- DLL compiles cleanly with Visual Studio 2026 + SDK 10.0.22621.0
- Scan discovers devices
- Connect → `discoverServices` → `discoverCharacteristics` completes on first attempt (previously hung ~10 s then timed out)
- Characteristic read / write / notify all function correctly
