### PR TITLE
Adds windows/linux/macOS target to the ComposeMultiplatform 3.0 Example Project

### DIFF
--- a/examples/ComposeMultiplatform-3.0-Example/build.gradle.kts
+++ b/examples/ComposeMultiplatform-3.0-Example/build.gradle.kts
@@ -7,6 +7,7 @@ buildscript {
 plugins {
     //trick: for the same plugin versions in all sub-modules
     kotlin("multiplatform").apply(false)
+    kotlin("jvm").apply(false)
     id("com.android.application").apply(false)
     id("com.android.library").apply(false)
     id("org.jetbrains.compose").apply(false)

--- a/examples/ComposeMultiplatform-3.0-Example/desktopBlueFalconExampleMP/build.gradle.kts
+++ b/examples/ComposeMultiplatform-3.0-Example/desktopBlueFalconExampleMP/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("jvm")
+    id("org.jetbrains.compose")
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
+dependencies {
+    implementation(project(":shared"))
+    implementation(compose.desktop.currentOs)
+}
+
+compose.desktop {
+    application {
+        mainClass = "MainKt"
+    }
+}

--- a/examples/ComposeMultiplatform-3.0-Example/desktopBlueFalconExampleMP/src/main/kotlin/Main.kt
+++ b/examples/ComposeMultiplatform-3.0-Example/desktopBlueFalconExampleMP/src/main/kotlin/Main.kt
@@ -1,0 +1,17 @@
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import com.example.bluefalconcomposemultiplatform.App
+import com.example.bluefalconcomposemultiplatform.di.AppModule
+
+fun main() = application {
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "Blue Falcon"
+    ) {
+        App(
+            darkTheme = false,
+            dynamicColor = false,
+            appModule = AppModule()
+        )
+    }
+}

--- a/examples/ComposeMultiplatform-3.0-Example/gradle.properties
+++ b/examples/ComposeMultiplatform-3.0-Example/gradle.properties
@@ -13,7 +13,8 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 org.jetbrains.compose.experimental.uikit.enabled=true
+org.jetbrains.compose.experimental.macos.enabled=true
 
 kotlin.version=2.3.0
 agp.version=8.3.0
-compose.version=1.6.11
+compose.version=1.8.0

--- a/examples/ComposeMultiplatform-3.0-Example/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/ComposeMultiplatform-3.0-Example/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Jun 25 11:57:55 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/ComposeMultiplatform-3.0-Example/settings.gradle.kts
+++ b/examples/ComposeMultiplatform-3.0-Example/settings.gradle.kts
@@ -26,13 +26,20 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        mavenLocal()
+        maven("https://jitpack.io") {
+            content {
+                includeGroup("com.github.weliem.blessed-bluez")
+                includeGroup("com.github.weliem")
+            }
+        }
     }
 }
 
 rootProject.name = "BlueFalconComposeMultiplatform"
 include(":androidBlueFalconExampleMP")
+include(":desktopBlueFalconExampleMP")
 include(":shared")

--- a/examples/ComposeMultiplatform-3.0-Example/shared/build.gradle.kts
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/build.gradle.kts
@@ -5,16 +5,37 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
 }
 
+val falconVersion = "3.2.0"
+
 kotlin {
     jvmToolchain(21)
     androidTarget()
+
+    // JVM desktop (Windows + Linux)
+    jvm()
+
+    // macOS native
+    macosArm64 {
+        binaries {
+            executable {
+                entryPoint = "main"
+            }
+        }
+    }
+    macosX64 {
+        binaries {
+            executable {
+                entryPoint = "main"
+            }
+        }
+    }
 
     targets.withType(org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget::class.java).all {
         binaries.withType(org.jetbrains.kotlin.gradle.plugin.mpp.Framework::class.java).all {
             export("dev.icerock.moko:mvvm-core:0.16.1")
         }
     }
-    
+
     listOf(
         iosX64(),
         iosArm64(),
@@ -33,9 +54,7 @@ kotlin {
                 implementation(compose.foundation)
                 implementation(compose.material3)
                 implementation(compose.materialIconsExtended)
-                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
-                implementation(compose.components.resources)
-                
+
                 // Use api() for mvvm-core since it's exported in iOS framework
                 api("dev.icerock.moko:mvvm-core:0.16.1")
                 implementation("dev.icerock.moko:mvvm-compose:0.16.1")
@@ -43,10 +62,10 @@ kotlin {
                 implementation("dev.icerock.moko:mvvm-flow-compose:0.16.1")
 
                 // Blue Falcon 3.0
-                implementation("dev.bluefalcon:blue-falcon-core:3.1.0")
-                implementation("dev.bluefalcon:blue-falcon-plugin-logging:3.1.0")
-                implementation("dev.bluefalcon:blue-falcon-plugin-retry:3.1.0")
-                implementation("dev.bluefalcon:blue-falcon-plugin-nordic-fota:3.1.0")
+                implementation("dev.bluefalcon:blue-falcon-core:$falconVersion")
+                implementation("dev.bluefalcon:blue-falcon-plugin-logging:$falconVersion")
+                implementation("dev.bluefalcon:blue-falcon-plugin-retry:$falconVersion")
+                implementation("dev.bluefalcon:blue-falcon-plugin-nordic-fota:$falconVersion")
             }
         }
         val commonTest by getting {
@@ -58,9 +77,9 @@ kotlin {
             dependencies {
                 implementation("androidx.appcompat:appcompat:1.6.1")
                 implementation("androidx.activity:activity-compose:1.7.2")
-                
+
                 // Blue Falcon Android Engine
-                implementation("dev.bluefalcon:blue-falcon-engine-android:3.0.0")
+                implementation("dev.bluefalcon:blue-falcon-engine-android:$falconVersion")
             }
         }
         val androidUnitTest by getting
@@ -70,7 +89,7 @@ kotlin {
         val iosMain by creating {
             dependencies {
                 // Blue Falcon iOS Engine
-                implementation("dev.bluefalcon:blue-falcon-engine-ios:3.1.0")
+                implementation("dev.bluefalcon:blue-falcon-engine-ios:$falconVersion")
             }
             dependsOn(commonMain)
             iosX64Main.dependsOn(this)
@@ -85,6 +104,30 @@ kotlin {
             iosX64Test.dependsOn(this)
             iosArm64Test.dependsOn(this)
             iosSimulatorArm64Test.dependsOn(this)
+        }
+
+        // JVM desktop (Windows, Linux, macOS via JNI)
+        val jvmMain by getting {
+            dependencies {
+                // Blue Falcon Windows Engine (JNI + WinRT, publish engines locally first)
+                implementation("dev.bluefalcon:blue-falcon-engine-windows:$falconVersion")
+                // Blue Falcon Linux Engine (BlueZ via Blessed)
+                implementation("dev.bluefalcon:blue-falcon-engine-rpi:$falconVersion")
+                // Blue Falcon macOS JVM Engine (JNI + CoreBluetooth, publish engines locally first)
+                implementation("dev.bluefalcon:blue-falcon-engine-macos-jvm:$falconVersion")
+            }
+        }
+
+        // macOS native (CoreBluetooth via Kotlin/Native cinterop)
+        val macosArm64Main by getting
+        val macosX64Main by getting
+        val macosMain by creating {
+            dependencies {
+                implementation("dev.bluefalcon:blue-falcon-engine-macos:$falconVersion")
+            }
+            dependsOn(commonMain)
+            macosArm64Main.dependsOn(this)
+            macosX64Main.dependsOn(this)
         }
     }
 }

--- a/examples/ComposeMultiplatform-3.0-Example/shared/src/jvmMain/kotlin/com/example/bluefalconcomposemultiplatform/core/presentation/BlueFalconTheme.desktop.kt
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/src/jvmMain/kotlin/com/example/bluefalconcomposemultiplatform/core/presentation/BlueFalconTheme.desktop.kt
@@ -1,0 +1,20 @@
+package com.example.bluefalconcomposemultiplatform.core.presentation
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import com.example.bluefalconcomposemultiplatform.ui.theme.DarkColorScheme
+import com.example.bluefalconcomposemultiplatform.ui.theme.LightColorScheme
+import com.example.bluefalconcomposemultiplatform.ui.theme.Typography
+
+@Composable
+actual fun BlueFalconTheme(
+    darkTheme: Boolean,
+    dynamicColor: Boolean,
+    content: @Composable () -> Unit
+) {
+    MaterialTheme(
+        colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/examples/ComposeMultiplatform-3.0-Example/shared/src/jvmMain/kotlin/com/example/bluefalconcomposemultiplatform/di/AppModule.desktop.kt
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/src/jvmMain/kotlin/com/example/bluefalconcomposemultiplatform/di/AppModule.desktop.kt
@@ -1,0 +1,47 @@
+package com.example.bluefalconcomposemultiplatform.di
+
+import dev.bluefalcon.core.BlueFalcon
+import dev.bluefalcon.core.BlueFalconEngine
+import dev.bluefalcon.engine.macos.jvm.MacosJvmEngine
+import dev.bluefalcon.engine.rpi.RpiEngine
+import dev.bluefalcon.engine.windows.WindowsEngine
+import dev.bluefalcon.plugins.logging.LogLevel
+import dev.bluefalcon.plugins.logging.LoggingPlugin
+import dev.bluefalcon.plugins.nordicfota.NordicFotaPlugin
+import dev.bluefalcon.plugins.retry.RetryPlugin
+
+actual class AppModule {
+    actual val fotaPlugin: NordicFotaPlugin = NordicFotaPlugin.create {
+        chunkSize = 256
+        autoConfirm = true
+        autoReset = true
+    }
+
+    actual val blueFalcon: BlueFalcon = BlueFalcon(
+        engine = createDesktopEngine()
+    ).apply {
+        plugins.install(LoggingPlugin(LoggingPlugin.Config().apply {
+            level = LogLevel.DEBUG
+            logDiscovery = true
+            logConnections = true
+            logGattOperations = true
+        })) { }
+
+        plugins.install(RetryPlugin(RetryPlugin.Config().apply {
+            maxRetries = 3
+            initialDelay = kotlin.time.Duration.parse("1s")
+        })) { }
+
+        plugins.install(fotaPlugin) { }
+    }
+}
+
+private fun createDesktopEngine(): BlueFalconEngine {
+    val os = System.getProperty("os.name").lowercase()
+    return when {
+        os.contains("win") -> WindowsEngine()
+        os.contains("linux") -> RpiEngine()
+        os.contains("mac") -> MacosJvmEngine()
+        else -> throw UnsupportedOperationException("No JVM BLE engine available for OS: '$os'")
+    }
+}

--- a/examples/ComposeMultiplatform-3.0-Example/shared/src/macosMain/kotlin/com/example/bluefalconcomposemultiplatform/core/presentation/BlueFalconTheme.macos.kt
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/src/macosMain/kotlin/com/example/bluefalconcomposemultiplatform/core/presentation/BlueFalconTheme.macos.kt
@@ -1,0 +1,20 @@
+package com.example.bluefalconcomposemultiplatform.core.presentation
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import com.example.bluefalconcomposemultiplatform.ui.theme.DarkColorScheme
+import com.example.bluefalconcomposemultiplatform.ui.theme.LightColorScheme
+import com.example.bluefalconcomposemultiplatform.ui.theme.Typography
+
+@Composable
+actual fun BlueFalconTheme(
+    darkTheme: Boolean,
+    dynamicColor: Boolean,
+    content: @Composable () -> Unit
+) {
+    MaterialTheme(
+        colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/examples/ComposeMultiplatform-3.0-Example/shared/src/macosMain/kotlin/com/example/bluefalconcomposemultiplatform/di/AppModule.macos.kt
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/src/macosMain/kotlin/com/example/bluefalconcomposemultiplatform/di/AppModule.macos.kt
@@ -1,0 +1,34 @@
+package com.example.bluefalconcomposemultiplatform.di
+
+import dev.bluefalcon.core.BlueFalcon
+import dev.bluefalcon.engine.macos.MacosEngine
+import dev.bluefalcon.plugins.logging.LogLevel
+import dev.bluefalcon.plugins.logging.LoggingPlugin
+import dev.bluefalcon.plugins.nordicfota.NordicFotaPlugin
+import dev.bluefalcon.plugins.retry.RetryPlugin
+
+actual class AppModule {
+    actual val fotaPlugin: NordicFotaPlugin = NordicFotaPlugin.create {
+        chunkSize = 256
+        autoConfirm = true
+        autoReset = true
+    }
+
+    actual val blueFalcon: BlueFalcon = BlueFalcon(
+        engine = MacosEngine()
+    ).apply {
+        plugins.install(LoggingPlugin(LoggingPlugin.Config().apply {
+            level = LogLevel.DEBUG
+            logDiscovery = true
+            logConnections = true
+            logGattOperations = true
+        })) { }
+
+        plugins.install(RetryPlugin(RetryPlugin.Config().apply {
+            maxRetries = 3
+            initialDelay = kotlin.time.Duration.parse("1s")
+        })) { }
+
+        plugins.install(fotaPlugin) { }
+    }
+}

--- a/examples/ComposeMultiplatform-3.0-Example/shared/src/macosMain/kotlin/main.kt
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/src/macosMain/kotlin/main.kt
@@ -1,0 +1,17 @@
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import com.example.bluefalconcomposemultiplatform.App
+import com.example.bluefalconcomposemultiplatform.di.AppModule
+
+fun main() = application {
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "Blue Falcon"
+    ) {
+        App(
+            darkTheme = false,
+            dynamicColor = false,
+            appModule = AppModule()
+        )
+    }
+}

--- a/library/engines/macos-jvm/build.gradle.kts
+++ b/library/engines/macos-jvm/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     kotlin("multiplatform") version "2.3.0"
     id("com.vanniktech.maven.publish") version "0.34.0"
@@ -7,16 +9,37 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    maven("https://jitpack.io") {
-        content {
-            includeGroup("com.github.weliem.blessed-bluez")
-            includeGroup("com.github.weliem")
-        }
-    }
 }
 
 val kotlinx_coroutines_version: String by project
 val versionEngines: String by project
+
+val isMacOs = DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX
+
+val generatedResourcesDir = layout.buildDirectory.dir("generated-resources")
+
+val compileNativeMacos by tasks.registering(Exec::class) {
+    enabled = isMacOs
+
+    val nativeSrcDir = file("native")
+    val outputDir = generatedResourcesDir.get().dir("natives").asFile
+
+    inputs.dir(nativeSrcDir)
+    outputs.dir(outputDir)
+
+    val javaHome = System.getenv("JAVA_HOME") ?: System.getProperty("java.home") ?: ""
+
+    commandLine(
+        "clang",
+        "-dynamiclib",
+        "-framework", "CoreBluetooth",
+        "-framework", "Foundation",
+        "-I", "$javaHome/include",
+        "-I", "$javaHome/include/darwin",
+        "$nativeSrcDir/BlueFalconJNI.m",
+        "-o", "${outputDir.absolutePath}/libbluefalcon-macos.dylib"
+    )
+}
 
 kotlin {
     jvmToolchain(17)
@@ -25,22 +48,23 @@ kotlin {
 
     sourceSets {
         val jvmMain by getting {
+            resources.srcDir(generatedResourcesDir)
             dependencies {
                 implementation(project(":core"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_coroutines_version")
-                // Blessed library for Raspberry Pi BLE
-                implementation("com.github.weliem.blessed-bluez:blessed:0.65")
-                implementation("com.github.hypfvieh:dbus-java-transport-native-unixsocket:4.3.2")
             }
         }
     }
+}
+
+tasks.named("jvmProcessResources") {
+    dependsOn(compileNativeMacos)
 }
 
 kotlin.sourceSets.all {
     languageSettings.optIn("kotlin.uuid.ExperimentalUuidApi")
 }
 
-// Publishing configuration
 group = "dev.bluefalcon"
 version = versionEngines
 
@@ -50,13 +74,13 @@ mavenPublishing {
 
     coordinates(
         groupId = "dev.bluefalcon",
-        artifactId = "blue-falcon-engine-rpi",
+        artifactId = "blue-falcon-engine-macos-jvm",
         version = versionEngines
     )
 
     pom {
-        name.set("Blue Falcon Raspberry Pi Engine")
-        description.set("Raspberry Pi BLE engine for Blue Falcon using BlueZ DBus")
+        name.set("Blue Falcon macOS JVM Engine")
+        description.set("macOS BLE engine for Blue Falcon — JVM/Compose Desktop via JNI + CoreBluetooth")
         url.set("https://github.com/Reedyuk/blue-falcon")
 
         licenses {
@@ -82,9 +106,7 @@ mavenPublishing {
     }
 }
 
-// Signing configuration
 signing {
-    // Only sign when publishing to Maven Central, not for local builds
     setRequired {
         gradle.taskGraph.allTasks.any {
             it.name.contains("publishTo") && it.name.contains("MavenCentral")

--- a/library/engines/macos-jvm/native/BlueFalconJNI.m
+++ b/library/engines/macos-jvm/native/BlueFalconJNI.m
@@ -1,0 +1,606 @@
+#import <Foundation/Foundation.h>
+#import <CoreBluetooth/CoreBluetooth.h>
+#include <jni.h>
+
+// Forward declaration
+@interface BlueFalconBLEBridge : NSObject <CBCentralManagerDelegate, CBPeripheralDelegate>
+@end
+
+// Global state — single engine instance (sufficient for the single-process app model)
+static JavaVM *gJvm = NULL;
+static jobject gEngineRef = NULL;
+static CBCentralManager *gCentralManager = NULL;
+static BlueFalconBLEBridge *gBridge = NULL;
+// All discovered/connected peripherals keyed by NSUUID string
+static NSMutableDictionary<NSString*, CBPeripheral*> *gPeripherals = NULL;
+static dispatch_queue_t gBLEQueue = NULL;
+
+// ---------------------------------------------------------------------------
+// JNI thread helpers
+// ---------------------------------------------------------------------------
+
+static JNIEnv* getEnv(jboolean *wasAttached) {
+    *wasAttached = JNI_FALSE;
+    if (!gJvm) return NULL;
+    JNIEnv *env = NULL;
+    jint ret = (*gJvm)->GetEnv(gJvm, (void **)&env, JNI_VERSION_1_6);
+    if (ret == JNI_EDETACHED) {
+        if ((*gJvm)->AttachCurrentThread(gJvm, (void **)&env, NULL) == JNI_OK) {
+            *wasAttached = JNI_TRUE;
+        } else {
+            return NULL;
+        }
+    }
+    return env;
+}
+
+static void releaseEnv(jboolean wasAttached) {
+    if (wasAttached && gJvm) {
+        (*gJvm)->DetachCurrentThread(gJvm);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+static jstring toJString(JNIEnv *env, NSString *str) {
+    if (!str) return NULL;
+    return (*env)->NewStringUTF(env, [str UTF8String]);
+}
+
+static jbyteArray toJByteArray(JNIEnv *env, NSData *data) {
+    if (!data) return NULL;
+    jsize len = (jsize)[data length];
+    jbyteArray arr = (*env)->NewByteArray(env, len);
+    if (arr && len > 0) {
+        (*env)->SetByteArrayRegion(env, arr, 0, len, (const jbyte *)[data bytes]);
+    }
+    return arr;
+}
+
+static NSString* toString(JNIEnv *env, jstring jstr) {
+    if (!jstr) return nil;
+    const char *cstr = (*env)->GetStringUTFChars(env, jstr, NULL);
+    NSString *result = [NSString stringWithUTF8String:cstr];
+    (*env)->ReleaseStringUTFChars(env, jstr, cstr);
+    return result;
+}
+
+static NSData* toNSData(JNIEnv *env, jbyteArray arr) {
+    if (!arr) return nil;
+    jsize len = (*env)->GetArrayLength(env, arr);
+    jbyte *bytes = (*env)->GetByteArrayElements(env, arr, NULL);
+    NSData *data = [NSData dataWithBytes:bytes length:len];
+    (*env)->ReleaseByteArrayElements(env, arr, bytes, JNI_ABORT);
+    return data;
+}
+
+// ---------------------------------------------------------------------------
+// Peripheral / service / characteristic lookup
+// ---------------------------------------------------------------------------
+
+static CBService* findService(CBPeripheral *p, NSString *svcUuid) {
+    for (CBService *s in p.services) {
+        if ([s.UUID.UUIDString caseInsensitiveCompare:svcUuid] == NSOrderedSame) return s;
+    }
+    return nil;
+}
+
+static CBCharacteristic* findCharacteristic(CBPeripheral *p, NSString *svcUuid, NSString *charUuid) {
+    CBService *s = findService(p, svcUuid);
+    if (!s) return nil;
+    for (CBCharacteristic *c in s.characteristics) {
+        if ([c.UUID.UUIDString caseInsensitiveCompare:charUuid] == NSOrderedSame) return c;
+    }
+    return nil;
+}
+
+static CBDescriptor* findDescriptor(CBPeripheral *p, NSString *svcUuid, NSString *charUuid, NSString *descUuid) {
+    CBCharacteristic *c = findCharacteristic(p, svcUuid, charUuid);
+    if (!c) return nil;
+    for (CBDescriptor *d in c.descriptors) {
+        if ([d.UUID.UUIDString caseInsensitiveCompare:descUuid] == NSOrderedSame) return d;
+    }
+    return nil;
+}
+
+// ---------------------------------------------------------------------------
+// Callback into the Kotlin engine
+// ---------------------------------------------------------------------------
+
+static void callVoid0(JNIEnv *env, const char *name, const char *sig) {
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, name, sig);
+    (*env)->DeleteLocalRef(env, cls);
+    if (m) (*env)->CallVoidMethod(env, gEngineRef, m);
+}
+
+// ---------------------------------------------------------------------------
+// Delegate class
+// ---------------------------------------------------------------------------
+
+@implementation BlueFalconBLEBridge
+
+#pragma mark - CBCentralManagerDelegate
+
+- (void)centralManagerDidUpdateState:(CBCentralManager *)central {
+    jboolean att; JNIEnv *env = getEnv(&att);
+    if (!env || !gEngineRef) { releaseEnv(att); return; }
+
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, "onManagerStateChanged", "(I)V");
+    (*env)->DeleteLocalRef(env, cls);
+    if (m) (*env)->CallVoidMethod(env, gEngineRef, m, (jint)central.state);
+    releaseEnv(att);
+}
+
+- (void)centralManager:(CBCentralManager *)central
+ didDiscoverPeripheral:(CBPeripheral *)peripheral
+     advertisementData:(NSDictionary<NSString *,id> *)advertisementData
+                  RSSI:(NSNumber *)RSSI {
+    NSString *uuid = peripheral.identifier.UUIDString;
+    @synchronized(gPeripherals) { gPeripherals[uuid] = peripheral; }
+
+    jboolean att; JNIEnv *env = getEnv(&att);
+    if (!env || !gEngineRef) { releaseEnv(att); return; }
+
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, "onDeviceDiscovered",
+        "(Ljava/lang/String;Ljava/lang/String;F)V");
+    (*env)->DeleteLocalRef(env, cls);
+
+    if (m) {
+        NSString *name = peripheral.name
+            ?: (NSString *)advertisementData[CBAdvertisementDataLocalNameKey];
+        jstring juuid = toJString(env, uuid);
+        jstring jname = name ? toJString(env, name) : NULL;
+        (*env)->CallVoidMethod(env, gEngineRef, m, juuid, jname, [RSSI floatValue]);
+        (*env)->DeleteLocalRef(env, juuid);
+        if (jname) (*env)->DeleteLocalRef(env, jname);
+    }
+    releaseEnv(att);
+}
+
+- (void)centralManager:(CBCentralManager *)central
+  didConnectPeripheral:(CBPeripheral *)peripheral {
+    peripheral.delegate = self;
+
+    jboolean att; JNIEnv *env = getEnv(&att);
+    if (!env || !gEngineRef) { releaseEnv(att); return; }
+
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, "onConnected", "(Ljava/lang/String;)V");
+    (*env)->DeleteLocalRef(env, cls);
+    if (m) {
+        jstring juuid = toJString(env, peripheral.identifier.UUIDString);
+        (*env)->CallVoidMethod(env, gEngineRef, m, juuid);
+        (*env)->DeleteLocalRef(env, juuid);
+    }
+    releaseEnv(att);
+}
+
+- (void)centralManager:(CBCentralManager *)central
+didDisconnectPeripheral:(CBPeripheral *)peripheral
+                 error:(NSError *)error {
+    jboolean att; JNIEnv *env = getEnv(&att);
+    if (!env || !gEngineRef) { releaseEnv(att); return; }
+
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, "onDisconnected", "(Ljava/lang/String;)V");
+    (*env)->DeleteLocalRef(env, cls);
+    if (m) {
+        jstring juuid = toJString(env, peripheral.identifier.UUIDString);
+        (*env)->CallVoidMethod(env, gEngineRef, m, juuid);
+        (*env)->DeleteLocalRef(env, juuid);
+    }
+    releaseEnv(att);
+}
+
+- (void)centralManager:(CBCentralManager *)central
+didFailToConnectPeripheral:(CBPeripheral *)peripheral
+                 error:(NSError *)error {
+    // Treat failed connection as disconnected
+    jboolean att; JNIEnv *env = getEnv(&att);
+    if (!env || !gEngineRef) { releaseEnv(att); return; }
+
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, "onDisconnected", "(Ljava/lang/String;)V");
+    (*env)->DeleteLocalRef(env, cls);
+    if (m) {
+        jstring juuid = toJString(env, peripheral.identifier.UUIDString);
+        (*env)->CallVoidMethod(env, gEngineRef, m, juuid);
+        (*env)->DeleteLocalRef(env, juuid);
+    }
+    releaseEnv(att);
+}
+
+#pragma mark - CBPeripheralDelegate
+
+- (void)peripheral:(CBPeripheral *)peripheral didDiscoverServices:(NSError *)error {
+    if (error) return;
+
+    NSArray<CBService *> *services = peripheral.services ?: @[];
+
+    jboolean att; JNIEnv *env = getEnv(&att);
+    if (!env || !gEngineRef) { releaseEnv(att); return; }
+
+    jclass strCls = (*env)->FindClass(env, "java/lang/String");
+    jobjectArray arr = (*env)->NewObjectArray(env, (jsize)services.count, strCls, NULL);
+    (*env)->DeleteLocalRef(env, strCls);
+
+    for (NSUInteger i = 0; i < services.count; i++) {
+        jstring js = toJString(env, services[i].UUID.UUIDString);
+        (*env)->SetObjectArrayElement(env, arr, (jsize)i, js);
+        (*env)->DeleteLocalRef(env, js);
+    }
+
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, "onServicesDiscovered",
+        "(Ljava/lang/String;[Ljava/lang/String;)V");
+    (*env)->DeleteLocalRef(env, cls);
+    if (m) {
+        jstring juuid = toJString(env, peripheral.identifier.UUIDString);
+        (*env)->CallVoidMethod(env, gEngineRef, m, juuid, arr);
+        (*env)->DeleteLocalRef(env, juuid);
+    }
+    (*env)->DeleteLocalRef(env, arr);
+    releaseEnv(att);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didDiscoverCharacteristicsForService:(CBService *)service
+             error:(NSError *)error {
+    if (error) return;
+
+    NSArray<CBCharacteristic *> *chars = service.characteristics ?: @[];
+    NSString *svcUuid = service.UUID.UUIDString;
+    NSString *periphUuid = peripheral.identifier.UUIDString;
+
+    jboolean att; JNIEnv *env = getEnv(&att);
+    if (!env || !gEngineRef) { releaseEnv(att); return; }
+
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, "onCharacteristicDiscovered",
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V");
+    (*env)->DeleteLocalRef(env, cls);
+
+    if (m) {
+        jstring jpuuid = toJString(env, periphUuid);
+        jstring jsuuid = toJString(env, svcUuid);
+        for (CBCharacteristic *c in chars) {
+            jstring jcuuid = toJString(env, c.UUID.UUIDString);
+            (*env)->CallVoidMethod(env, gEngineRef, m, jpuuid, jsuuid, jcuuid, (jint)c.properties);
+            (*env)->DeleteLocalRef(env, jcuuid);
+            // Kick off descriptor discovery so they're ready when needed
+            [peripheral discoverDescriptorsForCharacteristic:c];
+        }
+        (*env)->DeleteLocalRef(env, jpuuid);
+        (*env)->DeleteLocalRef(env, jsuuid);
+    }
+    releaseEnv(att);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error {
+    if (error || !characteristic.value) return;
+
+    jboolean att; JNIEnv *env = getEnv(&att);
+    if (!env || !gEngineRef) { releaseEnv(att); return; }
+
+    // Notify path for subscribed characteristics; read path for one-shot reads
+    const char *cbName = characteristic.isNotifying ? "onCharacteristicChanged" : "onCharacteristicRead";
+
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, cbName,
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B)V");
+    (*env)->DeleteLocalRef(env, cls);
+
+    if (m) {
+        jstring jpuuid = toJString(env, peripheral.identifier.UUIDString);
+        jstring jsuuid = toJString(env, characteristic.service.UUID.UUIDString);
+        jstring jcuuid = toJString(env, characteristic.UUID.UUIDString);
+        jbyteArray jval = toJByteArray(env, characteristic.value);
+        (*env)->CallVoidMethod(env, gEngineRef, m, jpuuid, jsuuid, jcuuid, jval);
+        (*env)->DeleteLocalRef(env, jpuuid);
+        (*env)->DeleteLocalRef(env, jsuuid);
+        (*env)->DeleteLocalRef(env, jcuuid);
+        if (jval) (*env)->DeleteLocalRef(env, jval);
+    }
+    releaseEnv(att);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didWriteValueForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error {
+    jboolean att; JNIEnv *env = getEnv(&att);
+    if (!env || !gEngineRef) { releaseEnv(att); return; }
+
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, "onCharacteristicWritten",
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V");
+    (*env)->DeleteLocalRef(env, cls);
+
+    if (m) {
+        jstring jpuuid = toJString(env, peripheral.identifier.UUIDString);
+        jstring jsuuid = toJString(env, characteristic.service.UUID.UUIDString);
+        jstring jcuuid = toJString(env, characteristic.UUID.UUIDString);
+        (*env)->CallVoidMethod(env, gEngineRef, m, jpuuid, jsuuid, jcuuid,
+            error == nil ? JNI_TRUE : JNI_FALSE);
+        (*env)->DeleteLocalRef(env, jpuuid);
+        (*env)->DeleteLocalRef(env, jsuuid);
+        (*env)->DeleteLocalRef(env, jcuuid);
+    }
+    releaseEnv(att);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didDiscoverDescriptorsForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error {
+    // Discovery happens automatically; no explicit Kotlin callback needed
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didUpdateValueForDescriptor:(CBDescriptor *)descriptor
+             error:(NSError *)error {
+    if (error || !descriptor.value) return;
+
+    // Coerce various descriptor value types to NSData
+    NSData *valueData = nil;
+    if ([descriptor.value isKindOfClass:[NSData class]]) {
+        valueData = (NSData *)descriptor.value;
+    } else if ([descriptor.value isKindOfClass:[NSNumber class]]) {
+        uint16_t val = CFSwapInt16HostToLittle([(NSNumber *)descriptor.value unsignedShortValue]);
+        valueData = [NSData dataWithBytes:&val length:sizeof(val)];
+    } else if ([descriptor.value isKindOfClass:[NSString class]]) {
+        valueData = [(NSString *)descriptor.value dataUsingEncoding:NSUTF8StringEncoding];
+    }
+    if (!valueData) return;
+
+    jboolean att; JNIEnv *env = getEnv(&att);
+    if (!env || !gEngineRef) { releaseEnv(att); return; }
+
+    jclass cls = (*env)->GetObjectClass(env, gEngineRef);
+    jmethodID m = (*env)->GetMethodID(env, cls, "onDescriptorRead",
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B)V");
+    (*env)->DeleteLocalRef(env, cls);
+
+    if (m) {
+        jstring jpuuid = toJString(env, peripheral.identifier.UUIDString);
+        jstring jsuuid = toJString(env, descriptor.characteristic.service.UUID.UUIDString);
+        jstring jcuuid = toJString(env, descriptor.characteristic.UUID.UUIDString);
+        jstring jduuid = toJString(env, descriptor.UUID.UUIDString);
+        jbyteArray jval = toJByteArray(env, valueData);
+        (*env)->CallVoidMethod(env, gEngineRef, m, jpuuid, jsuuid, jcuuid, jduuid, jval);
+        (*env)->DeleteLocalRef(env, jpuuid);
+        (*env)->DeleteLocalRef(env, jsuuid);
+        (*env)->DeleteLocalRef(env, jcuuid);
+        (*env)->DeleteLocalRef(env, jduuid);
+        if (jval) (*env)->DeleteLocalRef(env, jval);
+    }
+    releaseEnv(att);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didUpdateNotificationStateForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error {
+    // Notification state is reflected in characteristic.isNotifying; no extra callback needed
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+// JNI entry points
+// ---------------------------------------------------------------------------
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeInitialize(JNIEnv *env, jobject thiz) {
+    (*env)->GetJavaVM(env, &gJvm);
+
+    if (gEngineRef) (*env)->DeleteGlobalRef(env, gEngineRef);
+    gEngineRef = (*env)->NewGlobalRef(env, thiz);
+
+    gPeripherals = [NSMutableDictionary dictionary];
+    gBLEQueue = dispatch_queue_create("dev.bluefalcon.ble", DISPATCH_QUEUE_SERIAL);
+    gBridge = [[BlueFalconBLEBridge alloc] init];
+    gCentralManager = [[CBCentralManager alloc] initWithDelegate:gBridge queue:gBLEQueue];
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeScan(JNIEnv *env, jobject thiz,
+                                                                 jobjectArray serviceUuids) {
+    jsize count = (*env)->GetArrayLength(env, serviceUuids);
+    NSMutableArray<CBUUID *> *cbuuids = [NSMutableArray arrayWithCapacity:count];
+    for (jsize i = 0; i < count; i++) {
+        jstring js = (jstring)(*env)->GetObjectArrayElement(env, serviceUuids, i);
+        [cbuuids addObject:[CBUUID UUIDWithString:toString(env, js)]];
+        (*env)->DeleteLocalRef(env, js);
+    }
+    NSArray<CBUUID *> *filter = cbuuids.count > 0 ? cbuuids : nil;
+    NSDictionary *opts = @{CBCentralManagerScanOptionAllowDuplicatesKey: @YES};
+
+    dispatch_async(gBLEQueue, ^{
+        [gCentralManager scanForPeripheralsWithServices:filter options:opts];
+    });
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeStopScan(JNIEnv *env, jobject thiz) {
+    dispatch_async(gBLEQueue, ^{ [gCentralManager stopScan]; });
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeConnect(JNIEnv *env, jobject thiz,
+                                                                    jstring peripheralUuid) {
+    NSString *puuid = toString(env, peripheralUuid);
+    dispatch_async(gBLEQueue, ^{
+        CBPeripheral *p = gPeripherals[puuid];
+        if (p) [gCentralManager connectPeripheral:p options:nil];
+    });
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeDisconnect(JNIEnv *env, jobject thiz,
+                                                                       jstring peripheralUuid) {
+    NSString *puuid = toString(env, peripheralUuid);
+    dispatch_async(gBLEQueue, ^{
+        CBPeripheral *p = gPeripherals[puuid];
+        if (p) [gCentralManager cancelPeripheralConnection:p];
+    });
+}
+
+JNIEXPORT jint JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeGetConnectionState(JNIEnv *env,
+                                                                               jobject thiz,
+                                                                               jstring peripheralUuid) {
+    NSString *puuid = toString(env, peripheralUuid);
+    CBPeripheral *p = gPeripherals[puuid];
+    return p ? (jint)p.state : 0; // 0 = CBPeripheralStateDisconnected
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeDiscoverServices(JNIEnv *env,
+                                                                             jobject thiz,
+                                                                             jstring peripheralUuid) {
+    NSString *puuid = toString(env, peripheralUuid);
+    dispatch_async(gBLEQueue, ^{
+        CBPeripheral *p = gPeripherals[puuid];
+        if (p) [p discoverServices:nil];
+    });
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeDiscoverCharacteristics(JNIEnv *env,
+                                                                                    jobject thiz,
+                                                                                    jstring peripheralUuid,
+                                                                                    jstring serviceUuid) {
+    NSString *puuid = toString(env, peripheralUuid);
+    NSString *suuid = toString(env, serviceUuid);
+    dispatch_async(gBLEQueue, ^{
+        CBPeripheral *p = gPeripherals[puuid];
+        if (!p) return;
+        CBService *s = findService(p, suuid);
+        if (s) [p discoverCharacteristics:nil forService:s];
+    });
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeReadCharacteristic(JNIEnv *env,
+                                                                               jobject thiz,
+                                                                               jstring peripheralUuid,
+                                                                               jstring serviceUuid,
+                                                                               jstring characteristicUuid) {
+    NSString *puuid = toString(env, peripheralUuid);
+    NSString *suuid = toString(env, serviceUuid);
+    NSString *cuuid = toString(env, characteristicUuid);
+    dispatch_async(gBLEQueue, ^{
+        CBPeripheral *p = gPeripherals[puuid];
+        if (!p) return;
+        CBCharacteristic *c = findCharacteristic(p, suuid, cuuid);
+        if (c) [p readValueForCharacteristic:c];
+    });
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeWriteCharacteristic(JNIEnv *env,
+                                                                                jobject thiz,
+                                                                                jstring peripheralUuid,
+                                                                                jstring serviceUuid,
+                                                                                jstring characteristicUuid,
+                                                                                jbyteArray value,
+                                                                                jboolean withResponse) {
+    NSString *puuid = toString(env, peripheralUuid);
+    NSString *suuid = toString(env, serviceUuid);
+    NSString *cuuid = toString(env, characteristicUuid);
+    NSData *data = toNSData(env, value);
+    CBCharacteristicWriteType wtype = withResponse
+        ? CBCharacteristicWriteWithResponse : CBCharacteristicWriteWithoutResponse;
+
+    dispatch_async(gBLEQueue, ^{
+        CBPeripheral *p = gPeripherals[puuid];
+        if (!p) return;
+        CBCharacteristic *c = findCharacteristic(p, suuid, cuuid);
+        if (c) [p writeValue:data forCharacteristic:c type:wtype];
+    });
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeSetNotify(JNIEnv *env, jobject thiz,
+                                                                      jstring peripheralUuid,
+                                                                      jstring serviceUuid,
+                                                                      jstring characteristicUuid,
+                                                                      jboolean enable) {
+    NSString *puuid = toString(env, peripheralUuid);
+    NSString *suuid = toString(env, serviceUuid);
+    NSString *cuuid = toString(env, characteristicUuid);
+    dispatch_async(gBLEQueue, ^{
+        CBPeripheral *p = gPeripherals[puuid];
+        if (!p) return;
+        CBCharacteristic *c = findCharacteristic(p, suuid, cuuid);
+        if (c) [p setNotifyValue:(BOOL)enable forCharacteristic:c];
+    });
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeReadDescriptor(JNIEnv *env, jobject thiz,
+                                                                           jstring peripheralUuid,
+                                                                           jstring serviceUuid,
+                                                                           jstring characteristicUuid,
+                                                                           jstring descriptorUuid) {
+    NSString *puuid = toString(env, peripheralUuid);
+    NSString *suuid = toString(env, serviceUuid);
+    NSString *cuuid = toString(env, characteristicUuid);
+    NSString *duuid = toString(env, descriptorUuid);
+    dispatch_async(gBLEQueue, ^{
+        CBPeripheral *p = gPeripherals[puuid];
+        if (!p) return;
+        CBDescriptor *d = findDescriptor(p, suuid, cuuid, duuid);
+        if (d) [p readValueForDescriptor:d];
+    });
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeWriteDescriptor(JNIEnv *env, jobject thiz,
+                                                                            jstring peripheralUuid,
+                                                                            jstring serviceUuid,
+                                                                            jstring characteristicUuid,
+                                                                            jstring descriptorUuid,
+                                                                            jbyteArray value) {
+    NSString *puuid = toString(env, peripheralUuid);
+    NSString *suuid = toString(env, serviceUuid);
+    NSString *cuuid = toString(env, characteristicUuid);
+    NSString *duuid = toString(env, descriptorUuid);
+    NSData *data = toNSData(env, value);
+    dispatch_async(gBLEQueue, ^{
+        CBPeripheral *p = gPeripherals[puuid];
+        if (!p) return;
+        CBDescriptor *d = findDescriptor(p, suuid, cuuid, duuid);
+        if (d) [p writeValue:data forDescriptor:d];
+    });
+}
+
+JNIEXPORT void JNICALL
+Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeChangeMTU(JNIEnv *env, jobject thiz,
+                                                                      jstring peripheralUuid,
+                                                                      jint mtuSize) {
+    NSString *puuid = toString(env, peripheralUuid);
+    dispatch_async(gBLEQueue, ^{
+        CBPeripheral *p = gPeripherals[puuid];
+        if (!p) return;
+        // CoreBluetooth exposes the negotiated MTU; mtuSize hint is ignored
+        NSUInteger actualMtu = [p maximumWriteValueLengthForType:CBCharacteristicWriteWithResponse];
+
+        jboolean att; JNIEnv *cbEnv = getEnv(&att);
+        if (!cbEnv || !gEngineRef) { releaseEnv(att); return; }
+        jclass cls = (*cbEnv)->GetObjectClass(cbEnv, gEngineRef);
+        jmethodID m = (*cbEnv)->GetMethodID(cbEnv, cls, "onMtuChanged", "(Ljava/lang/String;I)V");
+        (*cbEnv)->DeleteLocalRef(cbEnv, cls);
+        if (m) {
+            jstring juuid = toJString(cbEnv, puuid);
+            (*cbEnv)->CallVoidMethod(cbEnv, gEngineRef, m, juuid, (jint)actualMtu);
+            (*cbEnv)->DeleteLocalRef(cbEnv, juuid);
+        }
+        releaseEnv(att);
+    });
+}

--- a/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmBluetoothCharacteristic.kt
+++ b/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmBluetoothCharacteristic.kt
@@ -1,0 +1,64 @@
+package dev.bluefalcon.engine.macos.jvm
+
+import dev.bluefalcon.core.BluetoothCharacteristic
+import dev.bluefalcon.core.BluetoothCharacteristicDescriptor
+import dev.bluefalcon.core.BluetoothService
+import dev.bluefalcon.core.Uuid
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+class MacosJvmBluetoothCharacteristic(
+    override val uuid: Uuid,
+    override val name: String?,
+    val peripheralUuid: String,
+    val serviceUuid: Uuid,
+    val properties: Int
+) : BluetoothCharacteristic {
+
+    private var _value: ByteArray? = null
+    private val _descriptors = mutableListOf<BluetoothCharacteristicDescriptor>()
+    private var _service: BluetoothService? = null
+    private val _notifications = MutableSharedFlow<ByteArray>(extraBufferCapacity = 64)
+
+    override val value: ByteArray?
+        get() = _value
+
+    override val descriptors: List<BluetoothCharacteristicDescriptor>
+        get() = _descriptors.toList()
+
+    override val notifications: SharedFlow<ByteArray>
+        get() = _notifications.asSharedFlow()
+
+    override val isNotifying: Boolean
+        get() = (properties and PROPERTY_NOTIFY) != 0
+
+    override val service: BluetoothService?
+        get() = _service
+
+    internal fun updateValue(value: ByteArray) { _value = value }
+
+    internal fun emitNotification(value: ByteArray) { _notifications.tryEmit(value.copyOf()) }
+
+    internal fun setService(service: BluetoothService) { _service = service }
+
+    internal fun addDescriptor(descriptor: BluetoothCharacteristicDescriptor) {
+        if (!_descriptors.contains(descriptor)) _descriptors.add(descriptor)
+    }
+
+    override fun equals(other: Any?): Boolean =
+        other is MacosJvmBluetoothCharacteristic && uuid == other.uuid && serviceUuid == other.serviceUuid
+
+    override fun hashCode(): Int = 31 * uuid.hashCode() + serviceUuid.hashCode()
+
+    companion object {
+        const val PROPERTY_BROADCAST = 0x01
+        const val PROPERTY_READ = 0x02
+        const val PROPERTY_WRITE_NO_RESPONSE = 0x04
+        const val PROPERTY_WRITE = 0x08
+        const val PROPERTY_NOTIFY = 0x10
+        const val PROPERTY_INDICATE = 0x20
+        const val PROPERTY_SIGNED_WRITE = 0x40
+        const val PROPERTY_EXTENDED_PROPS = 0x80
+    }
+}

--- a/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmBluetoothCharacteristicDescriptor.kt
+++ b/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmBluetoothCharacteristicDescriptor.kt
@@ -1,0 +1,34 @@
+package dev.bluefalcon.engine.macos.jvm
+
+import dev.bluefalcon.core.BluetoothCharacteristic
+import dev.bluefalcon.core.BluetoothCharacteristicDescriptor
+import dev.bluefalcon.core.Uuid
+
+class MacosJvmBluetoothCharacteristicDescriptor(
+    override val uuid: Uuid,
+    val peripheralUuid: String,
+    val serviceUuid: Uuid,
+    val characteristicUuid: Uuid
+) : BluetoothCharacteristicDescriptor {
+
+    private var _value: ByteArray? = null
+    private var _characteristic: BluetoothCharacteristic? = null
+
+    override val value: ByteArray?
+        get() = _value
+
+    override val characteristic: BluetoothCharacteristic?
+        get() = _characteristic
+
+    internal fun updateValue(value: ByteArray) { _value = value }
+
+    internal fun setCharacteristic(characteristic: BluetoothCharacteristic) {
+        _characteristic = characteristic
+    }
+
+    override fun equals(other: Any?): Boolean =
+        other is MacosJvmBluetoothCharacteristicDescriptor &&
+            uuid == other.uuid && characteristicUuid == other.characteristicUuid
+
+    override fun hashCode(): Int = 31 * uuid.hashCode() + characteristicUuid.hashCode()
+}

--- a/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmBluetoothPeripheral.kt
+++ b/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmBluetoothPeripheral.kt
@@ -1,0 +1,38 @@
+package dev.bluefalcon.engine.macos.jvm
+
+import dev.bluefalcon.core.BluetoothCharacteristic
+import dev.bluefalcon.core.BluetoothPeripheral
+import dev.bluefalcon.core.BluetoothService
+
+class MacosJvmBluetoothPeripheral(
+    override val uuid: String,
+    private val deviceName: String?
+) : BluetoothPeripheral {
+
+    private val _services = mutableListOf<BluetoothService>()
+
+    override val name: String?
+        get() = deviceName ?: uuid
+
+    override var rssi: Float? = null
+
+    override var mtuSize: Int? = null
+
+    override val services: List<BluetoothService>
+        get() = _services.toList()
+
+    override val characteristics: List<BluetoothCharacteristic>
+        get() = _services.flatMap { it.characteristics }
+
+    internal fun updateServices(services: List<BluetoothService>) {
+        _services.clear()
+        _services.addAll(services)
+    }
+
+    override fun equals(other: Any?): Boolean =
+        other is MacosJvmBluetoothPeripheral && other.uuid == uuid
+
+    override fun hashCode(): Int = uuid.hashCode()
+
+    override fun toString(): String = uuid
+}

--- a/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmBluetoothService.kt
+++ b/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmBluetoothService.kt
@@ -1,0 +1,23 @@
+package dev.bluefalcon.engine.macos.jvm
+
+import dev.bluefalcon.core.BluetoothCharacteristic
+import dev.bluefalcon.core.BluetoothService
+import dev.bluefalcon.core.Uuid
+
+class MacosJvmBluetoothService(
+    override val uuid: Uuid,
+    override val name: String?,
+    val peripheralUuid: String
+) : BluetoothService {
+
+    private val _characteristics = mutableListOf<BluetoothCharacteristic>()
+
+    override val characteristics: List<BluetoothCharacteristic>
+        get() = _characteristics.toList()
+
+    internal fun addCharacteristic(characteristic: BluetoothCharacteristic) {
+        if (!_characteristics.contains(characteristic)) {
+            _characteristics.add(characteristic)
+        }
+    }
+}

--- a/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmEngine.kt
+++ b/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmEngine.kt
@@ -1,0 +1,375 @@
+package dev.bluefalcon.engine.macos.jvm
+
+import dev.bluefalcon.core.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * macOS JVM implementation of [BlueFalconEngine] for Compose Desktop.
+ * Bridges to CoreBluetooth via JNI — requires libbluefalcon-macos.dylib bundled in resources.
+ */
+class MacosJvmEngine : BlueFalconEngine {
+
+    override val scope = CoroutineScope(Dispatchers.Default)
+
+    private val _peripherals = MutableStateFlow<Set<BluetoothPeripheral>>(emptySet())
+    override val peripherals: StateFlow<Set<BluetoothPeripheral>> = _peripherals.asStateFlow()
+
+    private val _managerState = MutableStateFlow(BluetoothManagerState.NotReady)
+    override val managerState: StateFlow<BluetoothManagerState> = _managerState.asStateFlow()
+
+    private val _characteristicNotifications = MutableSharedFlow<CharacteristicNotification>(extraBufferCapacity = 64)
+    override val characteristicNotifications: SharedFlow<CharacteristicNotification> = _characteristicNotifications
+
+    override var isScanning: Boolean = false
+        private set
+
+    private val connections = mutableMapOf<String, MacosJvmBluetoothPeripheral>()
+
+    init {
+        try {
+            nativeInitialize()
+        } catch (e: UnsatisfiedLinkError) {
+            _managerState.value = BluetoothManagerState.NotReady
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Callbacks invoked from native via JNI (must stay private, not internal)
+    // -------------------------------------------------------------------------
+
+    @Suppress("unused")
+    private fun onManagerStateChanged(state: Int) {
+        // CBManagerStatePoweredOn = 5
+        _managerState.value = if (state == 5) BluetoothManagerState.Ready else BluetoothManagerState.NotReady
+    }
+
+    @Suppress("unused")
+    private fun onDeviceDiscovered(uuid: String, name: String?, rssi: Float) {
+        val peripheral = MacosJvmBluetoothPeripheral(uuid, name).apply { this.rssi = rssi }
+        _peripherals.value = _peripherals.value + peripheral
+    }
+
+    @Suppress("unused")
+    private fun onConnected(peripheralUuid: String) {
+        if (!connections.containsKey(peripheralUuid)) {
+            connections[peripheralUuid] = MacosJvmBluetoothPeripheral(peripheralUuid, null)
+        }
+    }
+
+    @Suppress("unused")
+    private fun onDisconnected(peripheralUuid: String) {
+        connections.remove(peripheralUuid)
+    }
+
+    @Suppress("unused")
+    private fun onServicesDiscovered(peripheralUuid: String, serviceUuids: Array<String>) {
+        val peripheral = connections[peripheralUuid] ?: return
+        val services = serviceUuids.map { uuidStr ->
+            MacosJvmBluetoothService(
+                uuid = Uuid.parse(uuidStr),
+                name = null,
+                peripheralUuid = peripheralUuid
+            )
+        }
+        peripheral.updateServices(services)
+    }
+
+    @Suppress("unused")
+    private fun onCharacteristicDiscovered(
+        peripheralUuid: String,
+        serviceUuid: String,
+        characteristicUuid: String,
+        properties: Int
+    ) {
+        val peripheral = connections[peripheralUuid] ?: return
+        val service = peripheral.services
+            .find { it.uuid.toString().uppercase() == serviceUuid.uppercase() }
+            as? MacosJvmBluetoothService ?: return
+        val characteristic = MacosJvmBluetoothCharacteristic(
+            uuid = Uuid.parse(characteristicUuid),
+            name = null,
+            peripheralUuid = peripheralUuid,
+            serviceUuid = Uuid.parse(serviceUuid),
+            properties = properties
+        )
+        service.addCharacteristic(characteristic)
+    }
+
+    @Suppress("unused")
+    private fun onCharacteristicRead(
+        peripheralUuid: String,
+        serviceUuid: String,
+        characteristicUuid: String,
+        value: ByteArray
+    ) {
+        findCharacteristic(peripheralUuid, serviceUuid, characteristicUuid)?.updateValue(value)
+    }
+
+    @Suppress("unused")
+    private fun onCharacteristicChanged(
+        peripheralUuid: String,
+        serviceUuid: String,
+        characteristicUuid: String,
+        value: ByteArray
+    ) {
+        val peripheral = connections[peripheralUuid] ?: return
+        val characteristic = findCharacteristic(peripheralUuid, serviceUuid, characteristicUuid) ?: return
+        characteristic.updateValue(value)
+        characteristic.emitNotification(value)
+        _characteristicNotifications.tryEmit(
+            CharacteristicNotification(
+                peripheral = peripheral,
+                characteristic = characteristic,
+                value = value.copyOf()
+            )
+        )
+    }
+
+    @Suppress("unused")
+    private fun onCharacteristicWritten(
+        peripheralUuid: String,
+        serviceUuid: String,
+        characteristicUuid: String,
+        success: Boolean
+    ) {
+        // Write completion is conveyed through the suspend call returning normally
+    }
+
+    @Suppress("unused")
+    private fun onDescriptorRead(
+        peripheralUuid: String,
+        serviceUuid: String,
+        characteristicUuid: String,
+        descriptorUuid: String,
+        value: ByteArray
+    ) {
+        findDescriptor(peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid)?.updateValue(value)
+    }
+
+    @Suppress("unused")
+    private fun onMtuChanged(peripheralUuid: String, mtu: Int) {
+        connections[peripheralUuid]?.mtuSize = mtu
+    }
+
+    // -------------------------------------------------------------------------
+    // BlueFalconEngine implementation
+    // -------------------------------------------------------------------------
+
+    override suspend fun scan(filters: List<ServiceFilter>) {
+        isScanning = true
+        nativeScan(filters.map { it.uuid.toString() }.toTypedArray())
+    }
+
+    override suspend fun stopScanning() {
+        isScanning = false
+        nativeStopScan()
+    }
+
+    override fun clearPeripherals() {
+        _peripherals.value = emptySet()
+    }
+
+    override suspend fun connect(peripheral: BluetoothPeripheral, autoConnect: Boolean) {
+        val p = peripheral.asMacos()
+        connections[p.uuid] = p
+        nativeConnect(p.uuid)
+    }
+
+    override suspend fun disconnect(peripheral: BluetoothPeripheral) {
+        val p = peripheral.asMacos()
+        nativeDisconnect(p.uuid)
+        connections.remove(p.uuid)
+    }
+
+    override fun connectionState(peripheral: BluetoothPeripheral): BluetoothPeripheralState {
+        val p = peripheral as? MacosJvmBluetoothPeripheral ?: return BluetoothPeripheralState.Unknown
+        return try {
+            when (nativeGetConnectionState(p.uuid)) {
+                0 -> BluetoothPeripheralState.Disconnected
+                1 -> BluetoothPeripheralState.Connecting
+                2 -> BluetoothPeripheralState.Connected
+                3 -> BluetoothPeripheralState.Disconnecting
+                else -> BluetoothPeripheralState.Unknown
+            }
+        } catch (e: Exception) {
+            BluetoothPeripheralState.Unknown
+        }
+    }
+
+    override fun retrievePeripheral(identifier: String): BluetoothPeripheral? =
+        connections[identifier] ?: MacosJvmBluetoothPeripheral(identifier, null)
+
+    override fun requestConnectionPriority(peripheral: BluetoothPeripheral, priority: ConnectionPriority) {
+        // No-op on Apple platforms
+    }
+
+    override suspend fun discoverServices(peripheral: BluetoothPeripheral, serviceUUIDs: List<Uuid>) {
+        nativeDiscoverServices(peripheral.asMacos().uuid)
+    }
+
+    override suspend fun discoverCharacteristics(
+        peripheral: BluetoothPeripheral,
+        service: BluetoothService,
+        characteristicUUIDs: List<Uuid>
+    ) {
+        nativeDiscoverCharacteristics(peripheral.asMacos().uuid, service.uuid.toString())
+    }
+
+    override suspend fun readCharacteristic(
+        peripheral: BluetoothPeripheral,
+        characteristic: BluetoothCharacteristic
+    ) {
+        val c = characteristic.asMacos()
+        nativeReadCharacteristic(peripheral.asMacos().uuid, c.serviceUuid.toString(), c.uuid.toString())
+    }
+
+    override suspend fun writeCharacteristic(
+        peripheral: BluetoothPeripheral,
+        characteristic: BluetoothCharacteristic,
+        value: String,
+        writeType: Int?
+    ) {
+        writeCharacteristic(peripheral, characteristic, value.encodeToByteArray(), writeType)
+    }
+
+    override suspend fun writeCharacteristic(
+        peripheral: BluetoothPeripheral,
+        characteristic: BluetoothCharacteristic,
+        value: ByteArray,
+        writeType: Int?
+    ) {
+        val c = characteristic.asMacos()
+        val withResponse = writeType != 1
+        nativeWriteCharacteristic(
+            peripheral.asMacos().uuid, c.serviceUuid.toString(), c.uuid.toString(), value, withResponse
+        )
+    }
+
+    override suspend fun notifyCharacteristic(
+        peripheral: BluetoothPeripheral,
+        characteristic: BluetoothCharacteristic,
+        notify: Boolean
+    ) {
+        val c = characteristic.asMacos()
+        nativeSetNotify(peripheral.asMacos().uuid, c.serviceUuid.toString(), c.uuid.toString(), notify)
+    }
+
+    override suspend fun indicateCharacteristic(
+        peripheral: BluetoothPeripheral,
+        characteristic: BluetoothCharacteristic,
+        indicate: Boolean
+    ) {
+        // Notifications and indications share the same API on Apple
+        notifyCharacteristic(peripheral, characteristic, indicate)
+    }
+
+    override suspend fun readDescriptor(
+        peripheral: BluetoothPeripheral,
+        characteristic: BluetoothCharacteristic,
+        descriptor: BluetoothCharacteristicDescriptor
+    ) {
+        val c = characteristic.asMacos()
+        nativeReadDescriptor(
+            peripheral.asMacos().uuid, c.serviceUuid.toString(), c.uuid.toString(), descriptor.uuid.toString()
+        )
+    }
+
+    override suspend fun writeDescriptor(
+        peripheral: BluetoothPeripheral,
+        descriptor: BluetoothCharacteristicDescriptor,
+        value: ByteArray
+    ) {
+        val d = descriptor as? MacosJvmBluetoothCharacteristicDescriptor
+            ?: throw IllegalArgumentException("Descriptor must be a MacosJvmBluetoothCharacteristicDescriptor")
+        nativeWriteDescriptor(
+            peripheral.asMacos().uuid,
+            d.serviceUuid.toString(),
+            d.characteristicUuid.toString(),
+            d.uuid.toString(),
+            value
+        )
+    }
+
+    override suspend fun changeMTU(peripheral: BluetoothPeripheral, mtuSize: Int) {
+        nativeChangeMTU(peripheral.asMacos().uuid, mtuSize)
+    }
+
+    override fun refreshGattCache(peripheral: BluetoothPeripheral): Boolean = false
+
+    override suspend fun openL2capChannel(peripheral: BluetoothPeripheral, psm: Int) {
+        throw UnsupportedOperationException("L2CAP is not yet supported in the macOS JVM engine")
+    }
+
+    override suspend fun createBond(peripheral: BluetoothPeripheral) {
+        // Bonding is automatic on Apple; no action required
+    }
+
+    override suspend fun removeBond(peripheral: BluetoothPeripheral) {
+        // Must be done through System Preferences on macOS
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun findCharacteristic(
+        peripheralUuid: String,
+        serviceUuid: String,
+        characteristicUuid: String
+    ): MacosJvmBluetoothCharacteristic? =
+        connections[peripheralUuid]?.services
+            ?.find { it.uuid.toString().uppercase() == serviceUuid.uppercase() }
+            ?.characteristics
+            ?.find { it.uuid.toString().uppercase() == characteristicUuid.uppercase() }
+            as? MacosJvmBluetoothCharacteristic
+
+    private fun findDescriptor(
+        peripheralUuid: String,
+        serviceUuid: String,
+        characteristicUuid: String,
+        descriptorUuid: String
+    ): MacosJvmBluetoothCharacteristicDescriptor? =
+        findCharacteristic(peripheralUuid, serviceUuid, characteristicUuid)
+            ?.descriptors
+            ?.find { it.uuid.toString().uppercase() == descriptorUuid.uppercase() }
+            as? MacosJvmBluetoothCharacteristicDescriptor
+
+    private fun BluetoothPeripheral.asMacos(): MacosJvmBluetoothPeripheral =
+        this as? MacosJvmBluetoothPeripheral
+            ?: throw IllegalArgumentException("Peripheral must be a MacosJvmBluetoothPeripheral")
+
+    private fun BluetoothCharacteristic.asMacos(): MacosJvmBluetoothCharacteristic =
+        this as? MacosJvmBluetoothCharacteristic
+            ?: throw IllegalArgumentException("Characteristic must be a MacosJvmBluetoothCharacteristic")
+
+    // -------------------------------------------------------------------------
+    // Native declarations
+    // -------------------------------------------------------------------------
+
+    private external fun nativeInitialize()
+    private external fun nativeScan(serviceUuids: Array<String>)
+    private external fun nativeStopScan()
+    private external fun nativeConnect(peripheralUuid: String)
+    private external fun nativeDisconnect(peripheralUuid: String)
+    private external fun nativeGetConnectionState(peripheralUuid: String): Int
+    private external fun nativeDiscoverServices(peripheralUuid: String)
+    private external fun nativeDiscoverCharacteristics(peripheralUuid: String, serviceUuid: String)
+    private external fun nativeReadCharacteristic(peripheralUuid: String, serviceUuid: String, characteristicUuid: String)
+    private external fun nativeWriteCharacteristic(peripheralUuid: String, serviceUuid: String, characteristicUuid: String, value: ByteArray, withResponse: Boolean)
+    private external fun nativeSetNotify(peripheralUuid: String, serviceUuid: String, characteristicUuid: String, enable: Boolean)
+    private external fun nativeReadDescriptor(peripheralUuid: String, serviceUuid: String, characteristicUuid: String, descriptorUuid: String)
+    private external fun nativeWriteDescriptor(peripheralUuid: String, serviceUuid: String, characteristicUuid: String, descriptorUuid: String, value: ByteArray)
+    private external fun nativeChangeMTU(peripheralUuid: String, mtuSize: Int)
+
+    companion object {
+        init {
+            NativeLibLoader.load("natives/libbluefalcon-macos.dylib")
+        }
+    }
+}

--- a/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/NativeLibLoader.kt
+++ b/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/NativeLibLoader.kt
@@ -1,0 +1,15 @@
+package dev.bluefalcon.engine.macos.jvm
+
+import java.io.File
+
+internal object NativeLibLoader {
+    fun load(resourcePath: String) {
+        val stream = NativeLibLoader::class.java.classLoader?.getResourceAsStream(resourcePath)
+            ?: throw UnsatisfiedLinkError("Native library not found in resources: $resourcePath")
+        val ext = resourcePath.substringAfterLast('.')
+        val tmp = File.createTempFile("bluefalcon-native", ".$ext")
+        tmp.deleteOnExit()
+        stream.use { it.copyTo(tmp.outputStream()) }
+        System.load(tmp.absolutePath)
+    }
+}

--- a/library/engines/rpi/src/jvmMain/kotlin/dev/bluefalcon/engine/rpi/RpiEngine.kt
+++ b/library/engines/rpi/src/jvmMain/kotlin/dev/bluefalcon/engine/rpi/RpiEngine.kt
@@ -2,6 +2,7 @@ package dev.bluefalcon.engine.rpi
 
 import com.welie.blessed.*
 import com.welie.blessed.BluetoothPeripheral as BlessedPeripheral
+import com.welie.blessed.bluez.DbusHelper
 import dev.bluefalcon.core.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -10,6 +11,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
 
 /**
  * Raspberry Pi implementation of BlueFalconEngine using the Blessed library
@@ -47,7 +49,34 @@ class RpiEngine : BlueFalconEngine {
         }
     }
     
-    private val bluetoothManager = BluetoothCentralManager(bluetoothManagerCallback)
+    private val bluetoothManager: BluetoothCentralManager = run {
+        // blessed-bluez 0.64 sorts adapters by getDeviceName() (the last path component) ascending
+        // and returns the last one. On systems with /org/bluez/test, "test" > "hci0" so the wrong
+        // adapter is chosen. We bypass this by creating the connection ourselves, initialising the
+        // BluezSignalHandler singleton (normally done by package-private BluezAdapterProvider), and
+        // then calling the package-private BluetoothCentralManager constructor with the correct adapter.
+        val connection = DBusConnectionBuilder.forSystemBus().build()
+
+        // Initialise the BluezSignalHandler singleton that the CentralManager requires.
+        val signalHandlerClass = Class.forName("com.welie.blessed.BluezSignalHandler")
+        val createInstanceMethod = signalHandlerClass.getDeclaredMethod(
+            "createInstance",
+            org.freedesktop.dbus.connections.impl.DBusConnection::class.java
+        )
+        createInstanceMethod.isAccessible = true
+        createInstanceMethod.invoke(null, connection)
+
+        val hciAdapter = DbusHelper.findBluezAdapters(connection)
+            .filter { Regex("/hci\\d+$").containsMatchIn(it.dbusPath) }
+            .maxByOrNull { it.dbusPath }
+            ?: throw IllegalStateException("No Bluetooth HCI adapter found at /org/bluez/hciX")
+
+        val ctor = BluetoothCentralManager::class.java.declaredConstructors
+            .first { it.parameterCount == 3 }
+        ctor.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        ctor.newInstance(bluetoothManagerCallback, emptySet<String>(), hciAdapter) as BluetoothCentralManager
+    }
     
     override suspend fun scan(filters: List<ServiceFilter>) {
         isScanning = true

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -10,11 +10,11 @@ org.gradle.configureondemand = false
 android.useAndroidX=true
 android.enableJetifier=true
 
-version=3.1.1
-versionCore=3.1.1
-versionEngines=3.1.1
-versionPlugins=3.1.1
-versionLegacy=3.1.1
+version=3.2.0
+versionCore=3.2.0
+versionEngines=3.2.0
+versionPlugins=3.2.0
+versionLegacy=3.2.0
 group=dev.bluefalcon
 libraryName=blue-falcon
 kotlinx_coroutines_version=1.9.0

--- a/library/settings.gradle.kts
+++ b/library/settings.gradle.kts
@@ -25,6 +25,7 @@ include(":engines:js")
 include(":engines:windows")
 include(":engines:ios")
 include(":engines:macos")
+include(":engines:macos-jvm")
 
 // Include legacy compatibility layer
 include(":legacy")


### PR DESCRIPTION
Adds windows/linux/macOS target to the ComposeMultiplatform 3.0.
- Implemented JNI wrapper for MacOS so compose desktop can communicate with the binary
- Added patch to RPI so an Ubuntu linux client is able to select the correct device
- Updated version to 3.2.0

Ubuntu  
<img width="400" height="306" alt="Screenshot From 2026-05-05 11-14-18" src="https://github.com/user-attachments/assets/6d1ef889-2f5c-48eb-b720-a000dc748062" />

Windows  
<img width="400" height="303" alt="Screenshot From 2026-05-05 16-41-07" src="https://github.com/user-attachments/assets/afe92c2c-09de-4864-ad19-ac9b583c3f27" />

MacOS  
<img width="400" height="312" alt="image" src="https://github.com/user-attachments/assets/9b1e2f69-3cf3-42d9-83cc-0b0b3ae7c9ff" />
