### PR TITLE
Fix macOS JVM engine: notification routing and reconnect

### DIFF
--- a/library/engines/macos-jvm/native/BlueFalconJNI.m
+++ b/library/engines/macos-jvm/native/BlueFalconJNI.m
@@ -13,6 +13,9 @@ static CBCentralManager *gCentralManager = NULL;
 static BlueFalconBLEBridge *gBridge = NULL;
 // All discovered/connected peripherals keyed by NSUUID string
 static NSMutableDictionary<NSString*, CBPeripheral*> *gPeripherals = NULL;
+// Keys of in-flight explicit reads: "<peripheralUUID>:<characteristicUUID>".
+// Accessed only on gBLEQueue, so no locking is needed.
+static NSMutableSet<NSString*> *gPendingReads = NULL;
 static dispatch_queue_t gBLEQueue = NULL;
 
 // ---------------------------------------------------------------------------
@@ -289,8 +292,15 @@ didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic
     jboolean att; JNIEnv *env = getEnv(&att);
     if (!env || !gEngineRef) { releaseEnv(att); return; }
 
-    // Notify path for subscribed characteristics; read path for one-shot reads
-    const char *cbName = characteristic.isNotifying ? "onCharacteristicChanged" : "onCharacteristicRead";
+    // Route to onCharacteristicRead for explicit reads, onCharacteristicChanged for
+    // everything else (subscribed notifications, or values that arrive while isNotifying
+    // is still NO — i.e., between setNotifyValue:YES and the CCCD ACK).
+    // gPendingReads is accessed only on gBLEQueue, so no locking is needed.
+    NSString *key = [NSString stringWithFormat:@"%@:%@",
+        peripheral.identifier.UUIDString, characteristic.UUID.UUIDString];
+    BOOL isExplicitRead = [gPendingReads containsObject:key];
+    if (isExplicitRead) [gPendingReads removeObject:key];
+    const char *cbName = isExplicitRead ? "onCharacteristicRead" : "onCharacteristicChanged";
 
     jclass cls = (*env)->GetObjectClass(env, gEngineRef);
     jmethodID m = (*env)->GetMethodID(env, cls, cbName,
@@ -402,6 +412,7 @@ Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeInitialize(JNIEnv *env
     gEngineRef = (*env)->NewGlobalRef(env, thiz);
 
     gPeripherals = [NSMutableDictionary dictionary];
+    gPendingReads = [NSMutableSet set];
     gBLEQueue = dispatch_queue_create("dev.bluefalcon.ble", DISPATCH_QUEUE_SERIAL);
     gBridge = [[BlueFalconBLEBridge alloc] init];
     gCentralManager = [[CBCentralManager alloc] initWithDelegate:gBridge queue:gBLEQueue];
@@ -498,7 +509,11 @@ Java_dev_bluefalcon_engine_macos_jvm_MacosJvmEngine_nativeReadCharacteristic(JNI
         CBPeripheral *p = gPeripherals[puuid];
         if (!p) return;
         CBCharacteristic *c = findCharacteristic(p, suuid, cuuid);
-        if (c) [p readValueForCharacteristic:c];
+        if (c) {
+            NSString *key = [NSString stringWithFormat:@"%@:%@", puuid, c.UUID.UUIDString];
+            [gPendingReads addObject:key];
+            [p readValueForCharacteristic:c];
+        }
     });
 }
 

--- a/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmEngine.kt
+++ b/library/engines/macos-jvm/src/jvmMain/kotlin/dev/bluefalcon/engine/macos/jvm/MacosJvmEngine.kt
@@ -177,6 +177,7 @@ class MacosJvmEngine : BlueFalconEngine {
 
     override suspend fun connect(peripheral: BluetoothPeripheral, autoConnect: Boolean) {
         val p = peripheral.asMacos()
+        p.updateServices(emptyList())
         connections[p.uuid] = p
         nativeConnect(p.uuid)
     }


### PR DESCRIPTION
### Bug 1: `didUpdateValueForCharacteristic` routed via `isNotifying` (incorrect)

The native delegate used `characteristic.isNotifying` to decide whether to call `onCharacteristicChanged` or `onCharacteristicRead`. This flag is set by CoreBluetooth **after** the CCCD write acknowledgement arrives, so notifications that come in between `setNotifyValue:YES` and that ACK had `isNotifying == NO` and were silently swallowed by `onCharacteristicRead` (which does not emit to the shared flow). Any characteristic whose first notification arrived before the CCCD ACK was effectively invisible to subscribers.

**Fix:** track in-flight explicit reads in a `gPendingReads` set (keyed by `peripheralUUID:characteristicUUID`). `didUpdateValueForCharacteristic` checks the set: hit → `onCharacteristicRead` + remove key; miss → `onCharacteristicChanged`. The set is only ever accessed on `gBLEQueue` (serial), so no locking is needed.

### Bug 2: Reconnect uses stale service/characteristic cache

`MacosJvmBluetoothPeripheral` instances live in the `_peripherals` StateFlow and retain their services and characteristics across disconnects. On reconnect, `awaitCharacteristics()` in the core layer saw `services.size > 0` immediately and returned the old (now invalid) CoreBluetooth objects before fresh service discovery had run. Any notification arriving after `onServicesDiscovered` replaced the services would then be dropped because `findCharacteristic` returned null.

**Fix:** call `p.updateServices(emptyList())` at the top of `connect()` so the peripheral's cache is cleared before `nativeConnect` is called. `awaitCharacteristics()` then blocks correctly until `onServicesDiscovered` + `onCharacteristicDiscovered` populate fresh objects.
