### PR TITLE
Build Windows JNI DLL in CI, package into Maven, and optimize caching

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -22,13 +22,13 @@ jobs:
         distribution: 'temurin'
         
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v4
       
     - name: Build all modules
-      run: ./gradlew -p ./library build --parallel --no-daemon
+      run: ./gradlew -p ./library build --parallel
       
     - name: Run tests
-      run: ./gradlew -p ./library test --no-daemon
+      run: ./gradlew -p ./library test
 
   build-windows:
     name: Build (Windows)
@@ -44,10 +44,10 @@ jobs:
         distribution: 'temurin'
         
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v4
       
     - name: Build Windows engine
-      run: ./gradlew.bat -p ./library :engines:windows:build --no-daemon
+      run: ./gradlew.bat -p ./library :engines:windows:build
       
   verify-structure:
     name: Verify Module Structure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   release:
     types: [released]
+  workflow_dispatch: # Allows manual trigger from the GitHub UI for testing
 
 permissions:
   contents: read
@@ -14,8 +15,9 @@ env:
   ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASS }}
 
 jobs:
-  build-and-publish:
-    runs-on: macos-latest
+  build-windows-dll:
+    name: Build Windows JNI DLL
+    runs-on: windows-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -29,11 +31,47 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       
+    - name: Compile Native DLL
+      run: ./gradlew.bat -p ./library :engines:windows:compileNativeWindows --no-daemon
+      
+    - name: Upload Windows DLL
+      uses: actions/upload-artifact@v4
+      with:
+        name: bluefalcon-windows-dll
+        path: library/engines/windows/build/generated-resources/natives/bluefalcon-windows.dll
+
+  build-and-publish:
+    runs-on: macos-latest
+    needs: build-windows-dll
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+        
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+
+    - name: Download Windows DLL
+      uses: actions/download-artifact@v4
+      with:
+        name: bluefalcon-windows-dll
+        path: library/engines/windows/build/generated-resources/natives
+        
     - name: Build all modules
       run: ./gradlew -p ./library build --parallel --no-daemon
       
     - name: Publish to Maven Central
+      if: env.ORG_GRADLE_PROJECT_mavenCentralUsername != ''
       run: ./gradlew -p ./library publishAllPublicationsToMavenCentralRepository --no-daemon
+
+    - name: Publish to Maven Local (for testing)
+      if: env.ORG_GRADLE_PROJECT_mavenCentralUsername == ''
+      run: ./gradlew -p ./library publishToMavenLocal --no-daemon
       
     - name: Print published artifacts
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,6 @@ jobs:
     - name: Publish to Maven Central
       if: env.ORG_GRADLE_PROJECT_mavenCentralUsername != ''
       run: ./gradlew -p ./library publishAllPublicationsToMavenCentralRepository --no-daemon
-
-    - name: Publish to Maven Local (for testing)
-      if: env.ORG_GRADLE_PROJECT_mavenCentralUsername == ''
-      run: ./gradlew -p ./library publishToMavenLocal --no-daemon
       
     - name: Print published artifacts
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
         distribution: 'temurin'
         
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v4
       
     - name: Compile Native DLL
-      run: ./gradlew.bat -p ./library :engines:windows:compileNativeWindows --no-daemon
+      run: ./gradlew.bat -p ./library :engines:windows:compileNativeWindows
       
     - name: Upload Windows DLL
       uses: actions/upload-artifact@v4
@@ -54,7 +54,7 @@ jobs:
         distribution: 'temurin'
         
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Download Windows DLL
       uses: actions/download-artifact@v4
@@ -63,11 +63,11 @@ jobs:
         path: library/engines/windows/build/generated-resources/natives
         
     - name: Build all modules
-      run: ./gradlew -p ./library build --parallel --no-daemon
+      run: ./gradlew -p ./library build --parallel
       
     - name: Publish to Maven Central
       if: env.ORG_GRADLE_PROJECT_mavenCentralUsername != ''
-      run: ./gradlew -p ./library publishAllPublicationsToMavenCentralRepository --no-daemon
+      run: ./gradlew -p ./library publishAllPublicationsToMavenCentralRepository
       
     - name: Print published artifacts
       run: |

--- a/library/engines/windows/build.gradle.kts
+++ b/library/engines/windows/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     kotlin("multiplatform") version "2.3.0"
     id("com.vanniktech.maven.publish")
@@ -12,6 +14,42 @@ repositories {
 val kotlinx_coroutines_version: String by project
 val versionEngines: String by project
 
+val isWindows = DefaultNativePlatform.getCurrentOperatingSystem().isWindows
+val generatedResourcesDir = layout.buildDirectory.dir("generated-resources")
+
+val compileNativeWindows by tasks.registering {
+    enabled = isWindows
+
+    val nativeSrcDir = project(":").file("src/windowsMain/cpp")
+    val cmakeBuildDir = file("${layout.buildDirectory.get().asFile}/cmake-build")
+    val outputDir = file("${generatedResourcesDir.get().asFile}/natives")
+
+    inputs.dir(nativeSrcDir)
+    outputs.dir(outputDir)
+
+    doLast {
+        cmakeBuildDir.mkdirs()
+        outputDir.mkdirs()
+
+        exec {
+            workingDir = cmakeBuildDir
+            commandLine = listOf("cmake", nativeSrcDir.absolutePath, "-A", "x64")
+        }
+
+        exec {
+            workingDir = cmakeBuildDir
+            commandLine = listOf("cmake", "--build", ".", "--config", "Release")
+        }
+
+        val dllFile = File(cmakeBuildDir, "Release/bluefalcon-windows.dll")
+        if (dllFile.exists()) {
+            dllFile.copyTo(File(outputDir, "bluefalcon-windows.dll"), overwrite = true)
+        } else {
+            throw GradleException("Failed to find compiled DLL at ${dllFile.absolutePath}")
+        }
+    }
+}
+
 kotlin {
     jvmToolchain(17)
     
@@ -19,11 +57,18 @@ kotlin {
     
     sourceSets {
         val jvmMain by getting {
+            resources.srcDir(generatedResourcesDir)
             dependencies {
                 implementation(project(":core"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_coroutines_version")
             }
         }
+    }
+}
+
+tasks.named("jvmProcessResources") {
+    if (isWindows) {
+        dependsOn(compileNativeWindows)
     }
 }
 

--- a/library/engines/windows/build.gradle.kts
+++ b/library/engines/windows/build.gradle.kts
@@ -35,22 +35,24 @@ val compileNativeWindows by tasks.registering {
         buildDir.mkdirs()
         destDir.mkdirs()
 
-        val configureExit = ProcessBuilder("cmake", srcDir.absolutePath, "-A", "x64")
+        val configureProc = ProcessBuilder("cmake", srcDir.absolutePath, "-A", "x64")
             .directory(buildDir)
             .redirectOutput(ProcessBuilder.Redirect.INHERIT)
             .redirectError(ProcessBuilder.Redirect.INHERIT)
             .start()
-            .waitFor()
+        configureProc.outputStream.close()
+        val configureExit = configureProc.waitFor()
         if (configureExit != 0) {
             throw GradleException("CMake configure failed with exit code $configureExit")
         }
 
-        val buildExit = ProcessBuilder("cmake", "--build", ".", "--config", "Release")
+        val buildProc = ProcessBuilder("cmake", "--build", ".", "--config", "Release")
             .directory(buildDir)
             .redirectOutput(ProcessBuilder.Redirect.INHERIT)
             .redirectError(ProcessBuilder.Redirect.INHERIT)
             .start()
-            .waitFor()
+        buildProc.outputStream.close()
+        val buildExit = buildProc.waitFor()
         if (buildExit != 0) {
             throw GradleException("CMake build failed with exit code $buildExit")
         }

--- a/library/engines/windows/build.gradle.kts
+++ b/library/engines/windows/build.gradle.kts
@@ -4,6 +4,7 @@ import javax.inject.Inject
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.LocalState
 
 
 plugins {
@@ -24,7 +25,7 @@ abstract class CompileNativeWindowsTask @Inject constructor(
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
 
-    @get:Internal
+    @get:LocalState
     abstract val cmakeBuildDir: DirectoryProperty
 
     @TaskAction

--- a/library/engines/windows/build.gradle.kts
+++ b/library/engines/windows/build.gradle.kts
@@ -1,6 +1,10 @@
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+
 
 plugins {
     kotlin("multiplatform") version "2.3.0"
@@ -8,11 +12,13 @@ plugins {
     id("signing")
 }
 
+@CacheableTask
 abstract class CompileNativeWindowsTask @Inject constructor(
     private val execOperations: ExecOperations
 ) : DefaultTask() {
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val nativeSrcDir: DirectoryProperty
 
     @get:OutputDirectory
@@ -41,7 +47,7 @@ abstract class CompileNativeWindowsTask @Inject constructor(
 
         val buildResult = execOperations.exec {
             workingDir = buildDir
-            commandLine = listOf("cmake", "--build", ".", "--config", "Release")
+            commandLine = listOf("cmake", "--build", ".", "--config", "Release", "--parallel")
             isIgnoreExitValue = true
         }
         if (buildResult.exitValue != 0) {

--- a/library/engines/windows/build.gradle.kts
+++ b/library/engines/windows/build.gradle.kts
@@ -20,30 +20,42 @@ val generatedResourcesDir = layout.buildDirectory.dir("generated-resources")
 val compileNativeWindows by tasks.registering {
     enabled = isWindows
 
-    val nativeSrcDir = project(":").file("src/windowsMain/cpp")
-    val cmakeBuildDir = file("${layout.buildDirectory.get().asFile}/cmake-build")
-    val outputDir = file("${generatedResourcesDir.get().asFile}/natives")
+    val nativeSrc = project(":").file("src/windowsMain/cpp")
+    val cmakeBuild = file("${layout.buildDirectory.get().asFile}/cmake-build")
+    val output = file("${generatedResourcesDir.get().asFile}/natives")
 
-    inputs.dir(nativeSrcDir)
-    outputs.dir(outputDir)
+    inputs.dir(nativeSrc)
+    outputs.dir(output)
 
     doLast {
-        cmakeBuildDir.mkdirs()
-        outputDir.mkdirs()
+        val srcDir = nativeSrc
+        val buildDir = cmakeBuild
+        val destDir = output
 
-        exec {
-            workingDir = cmakeBuildDir
-            commandLine = listOf("cmake", nativeSrcDir.absolutePath, "-A", "x64")
+        buildDir.mkdirs()
+        destDir.mkdirs()
+
+        val configureExit = ProcessBuilder("cmake", srcDir.absolutePath, "-A", "x64")
+            .directory(buildDir)
+            .inheritIO()
+            .start()
+            .waitFor()
+        if (configureExit != 0) {
+            throw GradleException("CMake configure failed with exit code $configureExit")
         }
 
-        exec {
-            workingDir = cmakeBuildDir
-            commandLine = listOf("cmake", "--build", ".", "--config", "Release")
+        val buildExit = ProcessBuilder("cmake", "--build", ".", "--config", "Release")
+            .directory(buildDir)
+            .inheritIO()
+            .start()
+            .waitFor()
+        if (buildExit != 0) {
+            throw GradleException("CMake build failed with exit code $buildExit")
         }
 
-        val dllFile = File(cmakeBuildDir, "Release/bluefalcon-windows.dll")
+        val dllFile = File(buildDir, "Release/bluefalcon-windows.dll")
         if (dllFile.exists()) {
-            dllFile.copyTo(File(outputDir, "bluefalcon-windows.dll"), overwrite = true)
+            dllFile.copyTo(File(destDir, "bluefalcon-windows.dll"), overwrite = true)
         } else {
             throw GradleException("Failed to find compiled DLL at ${dllFile.absolutePath}")
         }

--- a/library/engines/windows/build.gradle.kts
+++ b/library/engines/windows/build.gradle.kts
@@ -1,9 +1,60 @@
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
 
 plugins {
     kotlin("multiplatform") version "2.3.0"
     id("com.vanniktech.maven.publish")
     id("signing")
+}
+
+abstract class CompileNativeWindowsTask @Inject constructor(
+    private val execOperations: ExecOperations
+) : DefaultTask() {
+
+    @get:InputDirectory
+    abstract val nativeSrcDir: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @get:Internal
+    abstract val cmakeBuildDir: DirectoryProperty
+
+    @TaskAction
+    fun compile() {
+        val srcDir = nativeSrcDir.get().asFile
+        val destDir = outputDir.get().asFile
+        val buildDir = cmakeBuildDir.get().asFile
+
+        buildDir.mkdirs()
+        destDir.mkdirs()
+
+        val configureResult = execOperations.exec {
+            workingDir = buildDir
+            commandLine = listOf("cmake", srcDir.absolutePath, "-A", "x64")
+            isIgnoreExitValue = true
+        }
+        if (configureResult.exitValue != 0) {
+            throw GradleException("CMake configure failed with exit code ${configureResult.exitValue}")
+        }
+
+        val buildResult = execOperations.exec {
+            workingDir = buildDir
+            commandLine = listOf("cmake", "--build", ".", "--config", "Release")
+            isIgnoreExitValue = true
+        }
+        if (buildResult.exitValue != 0) {
+            throw GradleException("CMake build failed with exit code ${buildResult.exitValue}")
+        }
+
+        val dllFile = File(buildDir, "Release/bluefalcon-windows.dll")
+        if (dllFile.exists()) {
+            dllFile.copyTo(File(destDir, "bluefalcon-windows.dll"), overwrite = true)
+        } else {
+            throw GradleException("Failed to find compiled DLL at ${dllFile.absolutePath}")
+        }
+    }
 }
 
 repositories {
@@ -17,53 +68,11 @@ val versionEngines: String by project
 val isWindows = DefaultNativePlatform.getCurrentOperatingSystem().isWindows
 val generatedResourcesDir = layout.buildDirectory.dir("generated-resources")
 
-val compileNativeWindows by tasks.registering {
+val compileNativeWindows by tasks.registering(CompileNativeWindowsTask::class) {
     enabled = isWindows
-
-    val nativeSrc = project(":").file("src/windowsMain/cpp")
-    val cmakeBuild = file("${layout.buildDirectory.get().asFile}/cmake-build")
-    val output = file("${generatedResourcesDir.get().asFile}/natives")
-
-    inputs.dir(nativeSrc)
-    outputs.dir(output)
-
-    doLast {
-        val srcDir = nativeSrc
-        val buildDir = cmakeBuild
-        val destDir = output
-
-        buildDir.mkdirs()
-        destDir.mkdirs()
-
-        val configureProc = ProcessBuilder("cmake", srcDir.absolutePath, "-A", "x64")
-            .directory(buildDir)
-            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
-            .redirectError(ProcessBuilder.Redirect.INHERIT)
-            .start()
-        configureProc.outputStream.close()
-        val configureExit = configureProc.waitFor()
-        if (configureExit != 0) {
-            throw GradleException("CMake configure failed with exit code $configureExit")
-        }
-
-        val buildProc = ProcessBuilder("cmake", "--build", ".", "--config", "Release")
-            .directory(buildDir)
-            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
-            .redirectError(ProcessBuilder.Redirect.INHERIT)
-            .start()
-        buildProc.outputStream.close()
-        val buildExit = buildProc.waitFor()
-        if (buildExit != 0) {
-            throw GradleException("CMake build failed with exit code $buildExit")
-        }
-
-        val dllFile = File(buildDir, "Release/bluefalcon-windows.dll")
-        if (dllFile.exists()) {
-            dllFile.copyTo(File(destDir, "bluefalcon-windows.dll"), overwrite = true)
-        } else {
-            throw GradleException("Failed to find compiled DLL at ${dllFile.absolutePath}")
-        }
-    }
+    nativeSrcDir.set(project(":").layout.projectDirectory.dir("src/windowsMain/cpp"))
+    cmakeBuildDir.set(layout.buildDirectory.dir("cmake-build"))
+    outputDir.set(generatedResourcesDir.map { it.dir("natives") })
 }
 
 kotlin {

--- a/library/engines/windows/build.gradle.kts
+++ b/library/engines/windows/build.gradle.kts
@@ -37,7 +37,8 @@ val compileNativeWindows by tasks.registering {
 
         val configureExit = ProcessBuilder("cmake", srcDir.absolutePath, "-A", "x64")
             .directory(buildDir)
-            .inheritIO()
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
             .start()
             .waitFor()
         if (configureExit != 0) {
@@ -46,7 +47,8 @@ val compileNativeWindows by tasks.registering {
 
         val buildExit = ProcessBuilder("cmake", "--build", ".", "--config", "Release")
             .directory(buildDir)
-            .inheritIO()
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
             .start()
             .waitFor()
         if (buildExit != 0) {

--- a/library/engines/windows/src/jvmMain/kotlin/dev/bluefalcon/engine/windows/NativeLibLoader.kt
+++ b/library/engines/windows/src/jvmMain/kotlin/dev/bluefalcon/engine/windows/NativeLibLoader.kt
@@ -9,7 +9,11 @@ internal object NativeLibLoader {
         val ext = resourcePath.substringAfterLast('.')
         val tmp = File.createTempFile("bluefalcon-native", ".$ext")
         tmp.deleteOnExit()
-        stream.use { it.copyTo(tmp.outputStream()) }
+        stream.use { input ->
+            tmp.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
         System.load(tmp.absolutePath)
     }
 }

--- a/library/engines/windows/src/jvmMain/kotlin/dev/bluefalcon/engine/windows/NativeLibLoader.kt
+++ b/library/engines/windows/src/jvmMain/kotlin/dev/bluefalcon/engine/windows/NativeLibLoader.kt
@@ -1,0 +1,15 @@
+package dev.bluefalcon.engine.windows
+
+import java.io.File
+
+internal object NativeLibLoader {
+    fun load(resourcePath: String) {
+        val stream = NativeLibLoader::class.java.classLoader?.getResourceAsStream(resourcePath)
+            ?: throw UnsatisfiedLinkError("Native library not found in resources: $resourcePath")
+        val ext = resourcePath.substringAfterLast('.')
+        val tmp = File.createTempFile("bluefalcon-native", ".$ext")
+        tmp.deleteOnExit()
+        stream.use { it.copyTo(tmp.outputStream()) }
+        System.load(tmp.absolutePath)
+    }
+}

--- a/library/engines/windows/src/jvmMain/kotlin/dev/bluefalcon/engine/windows/WindowsEngine.kt
+++ b/library/engines/windows/src/jvmMain/kotlin/dev/bluefalcon/engine/windows/WindowsEngine.kt
@@ -38,7 +38,13 @@ class WindowsEngine : BlueFalconEngine {
             nativeInitialize()
             _managerState.value = BluetoothManagerState.Ready
         } catch (e: UnsatisfiedLinkError) {
-            _managerState.value = BluetoothManagerState.NotReady
+            try {
+                NativeLibLoader.load("natives/bluefalcon-windows.dll")
+                nativeInitialize()
+                _managerState.value = BluetoothManagerState.Ready
+            } catch (ex: Exception) {
+                _managerState.value = BluetoothManagerState.NotReady
+            }
         } catch (e: Exception) {
             _managerState.value = BluetoothManagerState.NotReady
         }

--- a/library/engines/windows/src/jvmMain/kotlin/dev/bluefalcon/engine/windows/WindowsEngine.kt
+++ b/library/engines/windows/src/jvmMain/kotlin/dev/bluefalcon/engine/windows/WindowsEngine.kt
@@ -42,7 +42,7 @@ class WindowsEngine : BlueFalconEngine {
                 NativeLibLoader.load("natives/bluefalcon-windows.dll")
                 nativeInitialize()
                 _managerState.value = BluetoothManagerState.Ready
-            } catch (ex: Exception) {
+            } catch (ex: Throwable) {
                 _managerState.value = BluetoothManagerState.NotReady
             }
         } catch (e: Exception) {

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -36,3 +36,5 @@ developerOrganisationUrl=https://github.com/Reedyuk/
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 org.gradle.internal.publish.checksums.insecure=true
 org.gradle.configuration-cache=true
+org.gradle.caching=true
+

--- a/library/src/windowsMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/windowsMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -39,13 +39,17 @@ actual class BlueFalcon actual constructor(
                     ?: throw e
                 val tmp = java.io.File.createTempFile("bluefalcon-windows", ".dll")
                 tmp.deleteOnExit()
-                stream.use { it.copyTo(tmp.outputStream()) }
+                stream.use { input ->
+                    tmp.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
                 System.load(tmp.absolutePath)
                 nativeInitialize()
                 _managerState.value = BluetoothManagerState.Ready
                 log?.info("Windows Bluetooth initialized successfully from packaged resource")
-            } catch (ex: Exception) {
-                log?.error("Failed to load native library: ${e.message} and fallback: ${ex.message}")
+            } catch (ex: Throwable) {
+                log?.error("Failed to load native library: ${e.message} and fallback: ${ex.message}", cause = ex)
                 _managerState.value = BluetoothManagerState.NotReady
             }
         } catch (e: Exception) {

--- a/library/src/windowsMain/kotlin/dev/bluefalcon/BlueFalcon.kt
+++ b/library/src/windowsMain/kotlin/dev/bluefalcon/BlueFalcon.kt
@@ -32,8 +32,22 @@ actual class BlueFalcon actual constructor(
             _managerState.value = BluetoothManagerState.Ready
             log?.info("Windows Bluetooth initialized successfully")
         } catch (e: UnsatisfiedLinkError) {
-            log?.error("Failed to load native library: ${e.message}")
-            _managerState.value = BluetoothManagerState.NotReady
+            try {
+                // Try loading from classpath resources
+                val resourcePath = "natives/bluefalcon-windows.dll"
+                val stream = BlueFalcon::class.java.classLoader?.getResourceAsStream(resourcePath)
+                    ?: throw e
+                val tmp = java.io.File.createTempFile("bluefalcon-windows", ".dll")
+                tmp.deleteOnExit()
+                stream.use { it.copyTo(tmp.outputStream()) }
+                System.load(tmp.absolutePath)
+                nativeInitialize()
+                _managerState.value = BluetoothManagerState.Ready
+                log?.info("Windows Bluetooth initialized successfully from packaged resource")
+            } catch (ex: Exception) {
+                log?.error("Failed to load native library: ${e.message} and fallback: ${ex.message}")
+                _managerState.value = BluetoothManagerState.NotReady
+            }
         } catch (e: Exception) {
             log?.error("Failed to initialize Windows Bluetooth: ${e.message}")
             _managerState.value = BluetoothManagerState.NotReady


### PR DESCRIPTION
This PR addresses the distribution and compilation of the Windows JNI DLL on GitHub Actions as proposed in #218. It introduces a Windows runner to compile the native DLL, packages the compiled DLL into the Maven JVM resources for distribution, resolves configuration cache issues, and optimizes CI caching/runner times.

### Changes Implemented:
1. **Windows CI Compilation**:
   - Added a `build-windows-dll` job to the `Release` workflow on `windows-latest`.
   - Compiles the native JNI DLL and uploads it as an artifact.
   - The `build-and-publish` job downloads this artifact and packages it into the generated Maven JAR.
2. **Gradle Configuration Cache Compatibility**:
   - Created a custom Gradle task (`CompileNativeWindowsTask`) that safely handles CMake execution using ProcessBuilder and input/output properties to prevent configuration cache failures.
3. **Build Caching & Parallel Compilation**:
   - Enabled Gradle build caching globally (`org.gradle.caching=true`).
   - Marked the compilation task as `@CacheableTask` with path sensitivity so that DLL compilation is skipped entirely if C++ source files are unchanged.
   - Added `--parallel` compilation to CMake to speed up building.
4. **Upgraded Workflow Infrastructure**:
   - Replaced the deprecated `gradle-build-action@v2` with `setup-gradle@v4`.
   - Removed `--no-daemon` CLI flags to allow JVM daemon reuse and reduce runner overhead.

Resolves https://github.com/Reedyuk/blue-falcon/issues/218