### PR TITLE
fix: prepend/strip 2-byte SDU-length L-field in RPi L2CAP engine

### DIFF
--- a/library/engines/rpi/build.gradle.kts
+++ b/library/engines/rpi/build.gradle.kts
@@ -35,6 +35,11 @@ kotlin {
                 implementation("net.java.dev.jna:jna:5.14.0")
             }
         }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }
 

--- a/library/engines/rpi/src/jvmMain/kotlin/dev/bluefalcon/engine/rpi/RpiL2CapSocket.kt
+++ b/library/engines/rpi/src/jvmMain/kotlin/dev/bluefalcon/engine/rpi/RpiL2CapSocket.kt
@@ -56,8 +56,9 @@ class RpiL2CapSocket(
                 while (isActive) {
                     val read = clib.read(fd, buffer, NativeLong(READ_BUFFER_SIZE.toLong())).toLong()
                     if (read <= 0L) break
-                    // One SEQPACKET read == one whole SDU; strip the leading
-                    // 2-byte LE SDU-length L-field and emit the raw payload.
+                    // One SEQPACKET read == one whole SDU; strip the leading 2-byte
+                    // LE SDU-length L-field and emit the raw payload. A truncated or
+                    // malformed SDU yields null and is skipped rather than emitted.
                     val payload = stripSduLength(buffer.getByteArray(0, read.toInt())) ?: continue
                     _incoming.emit(payload)
                 }
@@ -98,29 +99,59 @@ class RpiL2CapSocket(
     }
 
     companion object {
-        private const val READ_BUFFER_SIZE = 4096
+        /** Size of the 2-octet little-endian SDU-length L-field BlueZ frames each CoC SDU with. */
+        private const val SDU_LENGTH_FIELD = 2
+
+        /**
+         * Maximum L2CAP LE CoC SDU payload. The L-field is 16-bit, so a payload cannot
+         * exceed this (Bluetooth Core Spec, Vol 3, Part A, §3.4).
+         */
+        private const val MAX_SDU_PAYLOAD = 0xFFFF
+
+        /**
+         * Inbound read buffer, sized to hold a whole maximum-length SDU (payload + L-field)
+         * so a spec-compliant peer's SDU is never truncated by the SEQPACKET `read()`.
+         * [stripSduLength] still validates the declared length and drops anything short.
+         */
+        private const val READ_BUFFER_SIZE = MAX_SDU_PAYLOAD + SDU_LENGTH_FIELD
 
         /**
          * Frames [payload] as a BlueZ L2CAP CoC SDU by prepending the 2-octet
          * little-endian SDU-length L-field. The length is the payload length,
          * excluding the 2-byte field itself. Inverse of [stripSduLength].
+         *
+         * @throws L2capException if [payload] exceeds [MAX_SDU_PAYLOAD] — the 16-bit
+         *   L-field cannot encode it, so framing it would silently wrap and corrupt the
+         *   stream. Fail fast instead.
          */
         internal fun frameSdu(payload: ByteArray): ByteArray {
-            val sdu = ByteArray(payload.size + 2)
+            if (payload.size > MAX_SDU_PAYLOAD) {
+                throw L2capException(
+                    "L2CAP SDU payload of ${payload.size} bytes exceeds the maximum of $MAX_SDU_PAYLOAD"
+                )
+            }
+            val sdu = ByteArray(payload.size + SDU_LENGTH_FIELD)
             sdu[0] = (payload.size and 0xFF).toByte()
             sdu[1] = ((payload.size ushr 8) and 0xFF).toByte()
-            payload.copyInto(sdu, destinationOffset = 2)
+            payload.copyInto(sdu, destinationOffset = SDU_LENGTH_FIELD)
             return sdu
         }
 
         /**
          * Strips the leading 2-octet LE SDU-length L-field that the Linux kernel
-         * exposes on each inbound CoC SDU, returning the raw payload. Returns
-         * `null` for a malformed SDU shorter than the 2-byte field.
+         * exposes on each inbound CoC SDU, returning the raw payload.
+         *
+         * Returns `null` for an SDU shorter than the 2-byte field, or one whose declared
+         * length disagrees with the bytes actually received — the latter signals a
+         * truncated (e.g. larger than [READ_BUFFER_SIZE]) or otherwise malformed SDU, so
+         * the partial payload is dropped rather than emitted as if it were valid.
          */
         internal fun stripSduLength(sdu: ByteArray): ByteArray? {
-            if (sdu.size < 2) return null
-            return sdu.copyOfRange(2, sdu.size)
+            if (sdu.size < SDU_LENGTH_FIELD) return null
+            val declaredLength = (sdu[0].toInt() and 0xFF) or ((sdu[1].toInt() and 0xFF) shl 8)
+            val payloadLength = sdu.size - SDU_LENGTH_FIELD
+            if (declaredLength != payloadLength) return null
+            return sdu.copyOfRange(SDU_LENGTH_FIELD, sdu.size)
         }
     }
 }

--- a/library/engines/rpi/src/jvmMain/kotlin/dev/bluefalcon/engine/rpi/RpiL2CapSocket.kt
+++ b/library/engines/rpi/src/jvmMain/kotlin/dev/bluefalcon/engine/rpi/RpiL2CapSocket.kt
@@ -24,6 +24,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  * A read loop on [Dispatchers.IO] drains the fd into [incoming]; [write] is
  * serialized through a [Mutex]. [close] closes the fd, which unblocks the
  * blocking `read` and ends the loop.
+ *
+ * BlueZ surfaces the LE Credit Based Flow Control **SDU-length L-field** (a
+ * 2-octet little-endian length) to userspace on this `SOCK_SEQPACKET` socket, so
+ * it is stripped from each inbound SDU and prepended to each outbound SDU here
+ * (see [frameSdu]/[stripSduLength]). [incoming] and [write] therefore carry raw
+ * payload only, matching the other engines and the [BluetoothSocket] contract.
  */
 class RpiL2CapSocket(
     private val fd: Int,
@@ -50,7 +56,10 @@ class RpiL2CapSocket(
                 while (isActive) {
                     val read = clib.read(fd, buffer, NativeLong(READ_BUFFER_SIZE.toLong())).toLong()
                     if (read <= 0L) break
-                    _incoming.emit(buffer.getByteArray(0, read.toInt()))
+                    // One SEQPACKET read == one whole SDU; strip the leading
+                    // 2-byte LE SDU-length L-field and emit the raw payload.
+                    val payload = stripSduLength(buffer.getByteArray(0, read.toInt())) ?: continue
+                    _incoming.emit(payload)
                 }
             } finally {
                 isOpen = false
@@ -61,22 +70,20 @@ class RpiL2CapSocket(
     override suspend fun write(data: ByteArray) {
         if (!isOpen) throw L2capException("L2CAP socket on PSM $psm is closed")
         if (data.isEmpty()) return
+        // Prepend the 2-byte LE SDU-length L-field and send the whole SDU as a
+        // single SEQPACKET message (one write() == one SDU; never loop-split it,
+        // or each chunk would be mis-framed as its own SDU).
+        val sdu = frameSdu(data)
         writeMutex.withLock {
             withContext(Dispatchers.IO) {
-                Memory(data.size.toLong()).use { buffer ->
-                    buffer.write(0, data, 0, data.size)
-                    var offset = 0
-                    while (offset < data.size) {
-                        val written = clib.write(
-                            fd,
-                            buffer.share(offset.toLong()),
-                            NativeLong((data.size - offset).toLong())
-                        ).toLong()
-                        if (written <= 0L) {
-                            isOpen = false
-                            throw L2capException("Failed to write to L2CAP socket on PSM $psm")
-                        }
-                        offset += written.toInt()
+                Memory(sdu.size.toLong()).use { buffer ->
+                    buffer.write(0, sdu, 0, sdu.size)
+                    val written = clib.write(fd, buffer, NativeLong(sdu.size.toLong())).toLong()
+                    if (written.toInt() != sdu.size) {
+                        isOpen = false
+                        throw L2capException(
+                            "Short/failed L2CAP write on PSM $psm ($written/${sdu.size})"
+                        )
                     }
                 }
             }
@@ -92,5 +99,28 @@ class RpiL2CapSocket(
 
     companion object {
         private const val READ_BUFFER_SIZE = 4096
+
+        /**
+         * Frames [payload] as a BlueZ L2CAP CoC SDU by prepending the 2-octet
+         * little-endian SDU-length L-field. The length is the payload length,
+         * excluding the 2-byte field itself. Inverse of [stripSduLength].
+         */
+        internal fun frameSdu(payload: ByteArray): ByteArray {
+            val sdu = ByteArray(payload.size + 2)
+            sdu[0] = (payload.size and 0xFF).toByte()
+            sdu[1] = ((payload.size ushr 8) and 0xFF).toByte()
+            payload.copyInto(sdu, destinationOffset = 2)
+            return sdu
+        }
+
+        /**
+         * Strips the leading 2-octet LE SDU-length L-field that the Linux kernel
+         * exposes on each inbound CoC SDU, returning the raw payload. Returns
+         * `null` for a malformed SDU shorter than the 2-byte field.
+         */
+        internal fun stripSduLength(sdu: ByteArray): ByteArray? {
+            if (sdu.size < 2) return null
+            return sdu.copyOfRange(2, sdu.size)
+        }
     }
 }

--- a/library/engines/rpi/src/jvmTest/kotlin/dev/bluefalcon/engine/rpi/RpiL2CapSocketTest.kt
+++ b/library/engines/rpi/src/jvmTest/kotlin/dev/bluefalcon/engine/rpi/RpiL2CapSocketTest.kt
@@ -1,0 +1,77 @@
+package dev.bluefalcon.engine.rpi
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the L2CAP CoC SDU-length framing in [RpiL2CapSocket].
+ *
+ * BlueZ surfaces the 2-octet little-endian SDU-length L-field to userspace on
+ * the raw socket, so the socket must prepend it on write ([RpiL2CapSocket.frameSdu])
+ * and strip it on read ([RpiL2CapSocket.stripSduLength]).
+ */
+class RpiL2CapSocketTest {
+
+    @Test
+    fun `frameSdu prepends the 2-byte little-endian payload length`() {
+        val payload = byteArrayOf(0x10, 0x20, 0x30)
+        val sdu = RpiL2CapSocket.frameSdu(payload)
+
+        assertEquals(payload.size + 2, sdu.size)
+        // length lo, length hi, then the untouched payload
+        assertEquals(0x03, sdu[0].toInt() and 0xFF)
+        assertEquals(0x00, sdu[1].toInt() and 0xFF)
+        assertTrue(payload.contentEquals(sdu.copyOfRange(2, sdu.size)))
+    }
+
+    @Test
+    fun `frameSdu encodes lengths above 255 as little-endian`() {
+        val payload = ByteArray(300) { it.toByte() }
+        val sdu = RpiL2CapSocket.frameSdu(payload)
+
+        // 300 == 0x012C -> lo = 0x2C, hi = 0x01
+        assertEquals(0x2C, sdu[0].toInt() and 0xFF)
+        assertEquals(0x01, sdu[1].toInt() and 0xFF)
+        assertEquals(302, sdu.size)
+    }
+
+    @Test
+    fun `frameSdu of an empty payload is just the zero length field`() {
+        val sdu = RpiL2CapSocket.frameSdu(ByteArray(0))
+
+        assertEquals(2, sdu.size)
+        assertEquals(0x00, sdu[0].toInt() and 0xFF)
+        assertEquals(0x00, sdu[1].toInt() and 0xFF)
+    }
+
+    @Test
+    fun `stripSduLength drops the 2-byte length field and returns the payload`() {
+        val sdu = byteArrayOf(0x03, 0x00, 0x10, 0x20, 0x30)
+        val payload = RpiL2CapSocket.stripSduLength(sdu)
+
+        assertTrue(byteArrayOf(0x10, 0x20, 0x30).contentEquals(payload))
+    }
+
+    @Test
+    fun `stripSduLength of frameSdu round-trips the payload byte-for-byte`() {
+        val payload = "hello l2cap".encodeToByteArray()
+        val roundTripped = RpiL2CapSocket.stripSduLength(RpiL2CapSocket.frameSdu(payload))
+
+        assertTrue(payload.contentEquals(roundTripped))
+    }
+
+    @Test
+    fun `stripSduLength of a bare length field yields an empty payload`() {
+        val payload = RpiL2CapSocket.stripSduLength(byteArrayOf(0x00, 0x00))
+
+        assertEquals(0, payload?.size)
+    }
+
+    @Test
+    fun `stripSduLength of a buffer shorter than the length field is null`() {
+        assertNull(RpiL2CapSocket.stripSduLength(byteArrayOf(0x01)))
+        assertNull(RpiL2CapSocket.stripSduLength(ByteArray(0)))
+    }
+}

--- a/library/engines/rpi/src/jvmTest/kotlin/dev/bluefalcon/engine/rpi/RpiL2CapSocketTest.kt
+++ b/library/engines/rpi/src/jvmTest/kotlin/dev/bluefalcon/engine/rpi/RpiL2CapSocketTest.kt
@@ -1,7 +1,9 @@
 package dev.bluefalcon.engine.rpi
 
+import dev.bluefalcon.core.L2capException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -35,6 +37,26 @@ class RpiL2CapSocketTest {
         assertEquals(0x2C, sdu[0].toInt() and 0xFF)
         assertEquals(0x01, sdu[1].toInt() and 0xFF)
         assertEquals(302, sdu.size)
+    }
+
+    @Test
+    fun `frameSdu accepts the maximum 65535-byte payload`() {
+        val payload = ByteArray(0xFFFF)
+        val sdu = RpiL2CapSocket.frameSdu(payload)
+
+        // 0xFFFF -> lo = 0xFF, hi = 0xFF
+        assertEquals(0xFF, sdu[0].toInt() and 0xFF)
+        assertEquals(0xFF, sdu[1].toInt() and 0xFF)
+        assertEquals(0xFFFF + 2, sdu.size)
+    }
+
+    @Test
+    fun `frameSdu fails fast when the payload exceeds the 16-bit L-field`() {
+        // 65536 bytes cannot be encoded in the 2-byte length field; framing it would
+        // wrap to 0 and corrupt the stream, so it must throw instead.
+        assertFailsWith<L2capException> {
+            RpiL2CapSocket.frameSdu(ByteArray(0x10000))
+        }
     }
 
     @Test
@@ -73,5 +95,20 @@ class RpiL2CapSocketTest {
     fun `stripSduLength of a buffer shorter than the length field is null`() {
         assertNull(RpiL2CapSocket.stripSduLength(byteArrayOf(0x01)))
         assertNull(RpiL2CapSocket.stripSduLength(ByteArray(0)))
+    }
+
+    @Test
+    fun `stripSduLength returns null when the declared length exceeds the received bytes`() {
+        // Declares 5 payload bytes but only 3 follow — a truncated SDU (e.g. it
+        // exceeded the read buffer). The partial payload must be dropped, not emitted.
+        val truncated = byteArrayOf(0x05, 0x00, 0x10, 0x20, 0x30)
+        assertNull(RpiL2CapSocket.stripSduLength(truncated))
+    }
+
+    @Test
+    fun `stripSduLength returns null when the declared length is shorter than the received bytes`() {
+        // Declares 1 payload byte but 3 follow — a malformed/over-long SDU.
+        val malformed = byteArrayOf(0x01, 0x00, 0x10, 0x20, 0x30)
+        assertNull(RpiL2CapSocket.stripSduLength(malformed))
     }
 }


### PR DESCRIPTION
## Problem

`RpiL2CapSocket` read from / wrote to a raw BlueZ L2CAP CoC `SOCK_SEQPACKET` socket and passed the bytes straight through. On Linux, CoC sockets surface the **2-octet little-endian SDU-length L-field** to userspace — it must be stripped from each inbound SDU and prepended to each outbound SDU by the application. The RPi engine did neither, so L2CAP transfers were byte-corrupted in **both** directions against any spec-compliant LE CoC peer:

- **Inbound:** every chunk on `incoming` was prefixed with 2 spurious length bytes, shifting the payload by 2.
- **Outbound:** `write(data)` sent the raw payload with no length field, so the peer's L2CAP stack mis-read the first 2 payload bytes as the SDU length.

The RPi engine was the only one out of step — Android (`BluetoothSocket` streams) and iOS/macOS (`CBL2CAPChannel` `NSStream`s) consume the L-field internally and already expose raw payload per the `BluetoothSocket` contract.

## Fix

Isolated to `RpiL2CapSocket` (no changes to `LinuxL2capNative`/`RpiEngine` or the other engines):

- Added two pure helpers: `frameSdu(payload)` (prepend 2-byte LE length, excluding the field itself) and `stripSduLength(sdu)` (drop the 2-byte field; returns `null` for a malformed `< 2`-byte SDU).
- **Read loop** strips the L-field and emits raw payload, skipping malformed SDUs.
- **Write** prepends the L-field and sends the whole SDU as a **single** `SOCK_SEQPACKET` datagram (was loop-split, which would emit multiple SDUs); short/failed writes close the socket and throw.
- Updated the class KDoc to document that `incoming`/`write` are payload-only.

## Tests

- New `jvmTest` source set for the rpi engine (it had none).
- `RpiL2CapSocketTest` — 7 tests: LE length prefix, lengths > 255 (little-endian `0x012C`), empty payload (`[0,0]`), strip-of-frame round-trip byte-for-byte, bare length field → empty payload, and `< 2`-byte buffer → `null`. All pass (`./gradlew :engines:rpi:jvmTest`).

## Note

`READ_BUFFER_SIZE` stays at 4096 — covers typical BLE CoC SDUs but isn't sized to the negotiated MTU, so a larger SDU would be truncated (MSG_TRUNC). Left as a potential follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)