### PR TITLE
fix(android): serialize GATT operations and reset stale state on reconnect

### DIFF
--- a/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidBluetoothPeripheral.kt
+++ b/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidBluetoothPeripheral.kt
@@ -21,13 +21,33 @@ class AndroidBluetoothPeripheral(val device: BluetoothDevice) : BluetoothPeriphe
     override val uuid: String
         get() = device.address
     
+    // Written from GATT callbacks on a binder thread (onReadRemoteRssi / onMtuChanged / scan results)
+    // and cleared from the main thread via resetConnectionState(); volatile gives the cross-thread
+    // happens-before so readers never observe a stale value or miss the reset.
+    @Volatile
     override var rssi: Float? = null
+    @Volatile
     override var mtuSize: Int? = null
     
     internal val _servicesFlow = MutableStateFlow<List<BluetoothService>>(emptyList())
-    
+
     override val characteristics: List<BluetoothCharacteristic>
         get() = services.flatMap { it.characteristics }
+
+    /**
+     * Clears transient per-connection state (discovered services and the negotiated MTU) so that a
+     * later reconnect using this same reused instance does not observe stale values from the previous
+     * connection. Without this, consumers that gate subscription work on "services discovered" /
+     * "MTU negotiated" proceed immediately against a connection that is still discovering, and the
+     * resulting CCC descriptor writes race the in-flight discovery and are silently dropped.
+     *
+     * [rssi] is intentionally preserved because it is also populated from scan results and remains a
+     * valid last-known value while disconnected.
+     */
+    internal fun resetConnectionState() {
+        _servicesFlow.value = emptyList()
+        mtuSize = null
+    }
     
     constructor(parcel: Parcel) : this(requireNotNull(parcel.readParcelable(BluetoothDevice::class.java.classLoader))) {
         rssi = parcel.readValue(Float::class.java.classLoader) as? Float

--- a/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidEngine.kt
+++ b/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidEngine.kt
@@ -122,11 +122,27 @@ class AndroidEngine(
     override fun clearPeripherals() {
         _peripherals.value = emptySet()
     }
-    
+
     override suspend fun connect(peripheral: BluetoothPeripheral, autoConnect: Boolean) {
         logger?.debug("Connecting to ${peripheral.name ?: peripheral.uuid}")
-        val device = (peripheral as? AndroidBluetoothPeripheral)?.device ?: return
-        device.connectGatt(context, autoConnect, gattCallback, transportMethod)
+        val androidPeripheral = (peripheral as? AndroidBluetoothPeripheral) ?: return
+        // Reset any stale per-connection state before reconnecting so consumers wait for the new
+        // connection's discovery/MTU instead of being satisfied instantly by the previous session's
+        // values. This also covers the case where the STATE_DISCONNECTED callback is delayed or never
+        // arrives. Reset both the caller's instance and the tracked instance in [_peripherals]; they
+        // are normally the same object, but a re-scan can produce a fresh instance.
+        androidPeripheral.resetConnectionState()
+        resetPeripheralState(androidPeripheral.device.address)
+        androidPeripheral.device.connectGatt(context, autoConnect, gattCallback, transportMethod)
+    }
+
+    private fun peripheralFor(address: String): AndroidBluetoothPeripheral? =
+        _peripherals.value.firstOrNull {
+            (it as? AndroidBluetoothPeripheral)?.device?.address == address
+        } as? AndroidBluetoothPeripheral
+
+    private fun resetPeripheralState(address: String) {
+        peripheralFor(address)?.resetConnectionState()
     }
     
     override suspend fun disconnect(peripheral: BluetoothPeripheral) {
@@ -169,9 +185,13 @@ class AndroidEngine(
     
     override suspend fun discoverServices(peripheral: BluetoothPeripheral, serviceUUIDs: List<Uuid>) {
         val device = (peripheral as? AndroidBluetoothPeripheral)?.device ?: return
-        gattCallback.gattsForDevice(device).forEach { it.discoverServices() }
+        gattCallback.gattsForDevice(device).forEach { gatt ->
+            gattCallback.enqueueOperation(gatt, GattOperationType.DISCOVER_SERVICES, "discoverServices") {
+                it.discoverServices()
+            }
+        }
     }
-    
+
     override suspend fun discoverCharacteristics(
         peripheral: BluetoothPeripheral,
         service: BluetoothService,
@@ -180,15 +200,28 @@ class AndroidEngine(
         val device = (peripheral as? AndroidBluetoothPeripheral)?.device ?: return
         val androidPeripheral = peripheral as AndroidBluetoothPeripheral
         if (!androidPeripheral.services.any { it.uuid == service.uuid }) {
-            gattCallback.gattsForDevice(device).forEach { it.discoverServices() }
+            gattCallback.gattsForDevice(device).forEach { gatt ->
+                gattCallback.enqueueOperation(gatt, GattOperationType.DISCOVER_SERVICES, "discoverServices") {
+                    it.discoverServices()
+                }
+            }
         }
     }
-    
+
     override suspend fun readCharacteristic(peripheral: BluetoothPeripheral, characteristic: BluetoothCharacteristic) {
         val device = (peripheral as? AndroidBluetoothPeripheral)?.device ?: return
         val androidChar = (characteristic as? AndroidBluetoothCharacteristic)?.characteristic ?: return
         gattCallback.gattsForDevice(device).forEach { gatt ->
-            fetchCharacteristic(androidChar, gatt).forEach { gatt.readCharacteristic(it) }
+            fetchCharacteristic(androidChar, gatt).forEach { char ->
+                gattCallback.enqueueOperation(
+                    gatt,
+                    GattOperationType.READ_CHAR,
+                    "readCharacteristic ${char.uuid}",
+                    identity = char.uuid.toString()
+                ) {
+                    it.readCharacteristic(char)
+                }
+            }
         }
     }
     
@@ -211,12 +244,24 @@ class AndroidEngine(
         logger?.debug("Writing value {length = ${value.size}, bytes = 0x${value.toHexString()}} with response $writeType")
         val device = (peripheral as? AndroidBluetoothPeripheral)?.device ?: return
         val androidChar = (characteristic as? AndroidBluetoothCharacteristic)?.characteristic ?: return
-        
+
+        // Snapshot the payload so a caller that reuses/mutates its array after this call cannot change
+        // the bytes that get written when the queued operation is finally dispatched.
+        val payload = value.copyOf()
         gattCallback.gattsForDevice(device).forEach { gatt ->
             fetchCharacteristic(androidChar, gatt).forEach { char ->
-                writeType?.let { char.writeType = it }
-                char.setValue(value)
-                gatt.writeCharacteristic(char)
+                gattCallback.enqueueOperation(
+                    gatt,
+                    GattOperationType.WRITE_CHAR,
+                    "writeCharacteristic ${char.uuid}",
+                    identity = char.uuid.toString()
+                ) {
+                    // Apply the value/writeType at dispatch time so a queued write never mutates the
+                    // characteristic while a previously queued operation on it is still in flight.
+                    writeType?.let { wt -> char.writeType = wt }
+                    char.setValue(payload)
+                    it.writeCharacteristic(char)
+                }
             }
         }
     }
@@ -256,10 +301,19 @@ class AndroidEngine(
     ) {
         val device = (peripheral as? AndroidBluetoothPeripheral)?.device ?: return
         val androidDesc = (descriptor as? AndroidBluetoothCharacteristicDescriptor)?.descriptor ?: return
-        gattCallback.gattsForDevice(device).forEach { it.readDescriptor(androidDesc) }
+        gattCallback.gattsForDevice(device).forEach { gatt ->
+            gattCallback.enqueueOperation(
+                gatt,
+                GattOperationType.READ_DESC,
+                "readDescriptor ${androidDesc.uuid}",
+                identity = androidDesc.uuid.toString()
+            ) {
+                it.readDescriptor(androidDesc)
+            }
+        }
         logger?.debug("readDescriptor -> ${descriptor.uuid}")
     }
-    
+
     override suspend fun writeDescriptor(
         peripheral: BluetoothPeripheral,
         descriptor: BluetoothCharacteristicDescriptor,
@@ -268,17 +322,31 @@ class AndroidEngine(
         logger?.debug("writeDescriptor ${descriptor.uuid} value: $value")
         val device = (peripheral as? AndroidBluetoothPeripheral)?.device ?: return
         val androidDesc = (descriptor as? AndroidBluetoothCharacteristicDescriptor)?.descriptor ?: return
-        
+
+        // Snapshot the payload so a caller that reuses/mutates its array after this call cannot change
+        // the bytes that get written when the queued operation is finally dispatched.
+        val payload = value.copyOf()
         gattCallback.gattsForDevice(device).forEach { gatt ->
-            androidDesc.value = value
-            gatt.writeDescriptor(androidDesc)
+            gattCallback.enqueueOperation(
+                gatt,
+                GattOperationType.WRITE_DESC,
+                "writeDescriptor ${androidDesc.uuid}",
+                identity = androidDesc.uuid.toString()
+            ) {
+                androidDesc.value = payload
+                it.writeDescriptor(androidDesc)
+            }
         }
     }
-    
+
     override suspend fun changeMTU(peripheral: BluetoothPeripheral, mtuSize: Int) {
         logger?.debug("changeMTU -> ${peripheral.uuid} mtuSize: $mtuSize")
         val device = (peripheral as? AndroidBluetoothPeripheral)?.device ?: return
-        gattCallback.gattsForDevice(device).forEach { it.requestMtu(mtuSize) }
+        gattCallback.gattsForDevice(device).forEach { gatt ->
+            gattCallback.enqueueOperation(gatt, GattOperationType.MTU, "requestMtu $mtuSize") {
+                it.requestMtu(mtuSize)
+            }
+        }
     }
     
     override fun refreshGattCache(peripheral: BluetoothPeripheral): Boolean {
@@ -366,11 +434,23 @@ class AndroidEngine(
         
         gattCallback.gattsForDevice(device).forEach { gatt ->
             fetchCharacteristic(androidChar, gatt).forEach { char ->
+                // setCharacteristicNotification only toggles local delivery; it issues no GATT
+                // transaction and produces no callback, so it is safe to apply immediately. The CCC
+                // descriptor write is the actual GATT operation and must be serialized through the
+                // queue so it cannot race service discovery (the root cause of the reconnect bug).
                 gatt.setCharacteristicNotification(char, enable)
-                descriptorValue?.let { value ->
+                descriptorValue?.let { rawValue ->
+                    val payload = rawValue.copyOf()
                     char.descriptors.forEach { descriptor ->
-                        descriptor.value = value
-                        gatt.writeDescriptor(descriptor)
+                        gattCallback.enqueueOperation(
+                            gatt,
+                            GattOperationType.WRITE_DESC,
+                            "writeDescriptor(CCC) ${descriptor.uuid} enable=$enable",
+                            identity = descriptor.uuid.toString()
+                        ) {
+                            descriptor.value = payload
+                            it.writeDescriptor(descriptor)
+                        }
                     }
                 }
             }
@@ -430,46 +510,108 @@ class AndroidEngine(
         internal val gatts: MutableList<BluetoothGatt> = CopyOnWriteArrayList()
         private val disconnectHandler = Handler(Looper.getMainLooper())
         private val pendingTimeouts = java.util.concurrent.ConcurrentHashMap<String, Runnable>()
-        
-        private fun addGatt(gatt: BluetoothGatt) {
-            if (gatts.firstOrNull { it.device.address == gatt.device.address } == null) {
+        private val operationQueues = java.util.concurrent.ConcurrentHashMap<BluetoothGatt, GattOperationQueue>()
+
+        // Guards every compound read-modify-write over [gatts]/[operationQueues] and the "is this the
+        // last gatt for the address?" reset decision. These run on three different threads — GATT
+        // callbacks on a binder thread, the disconnect watchdog on the main thread, and operation
+        // enqueues on the caller's thread — so check-then-act sequences must be serialized. Lock order
+        // is always gattLock -> queue monitor; no path takes them the other way, so there is no
+        // deadlock with [GattOperationQueue]'s per-instance synchronization.
+        private val gattLock = Any()
+
+        private fun addGatt(gatt: BluetoothGatt) = synchronized(gattLock) {
+            // Replace any stale same-address gatt from a previous connection. On a fast reconnect the
+            // new connection's STATE_CONNECTED can arrive before the old gatt's STATE_DISCONNECTED (or
+            // its force-close timeout); without this, the new gatt would be dropped and every later op
+            // would target the dead one. connectGatt always returns a fresh instance, so an existing
+            // entry with the same address but different identity is always stale.
+            val existing = gatts.firstOrNull { it.device.address == gatt.device.address }
+            if (existing != null && existing !== gatt) {
+                closeAndForget(existing)
+            }
+            if (gatts.none { it === gatt }) {
                 gatts.add(gatt)
             }
         }
-        
-        fun removeGatt(gatt: BluetoothGatt) {
+
+        /**
+         * Removes, closes and forgets [gatt], clearing its operation queue and — only when no newer
+         * gatt for the same address remains tracked — the reused peripheral's stale connection state.
+         * Idempotent, so it is safe if both STATE_DISCONNECTED and the force-close watchdog fire.
+         */
+        private fun closeAndForget(gatt: BluetoothGatt) = synchronized(gattLock) {
+            cancelDisconnectTimeout(gatt.device.address)
             gatts.remove(gatt)
+            operationQueues.remove(gatt)?.clear()
+            try {
+                gatt.close()
+            } catch (e: Exception) {
+                logger?.error("Error closing gatt for ${gatt.device.address}: ${e.message}")
+            }
+            if (gattsForDevice(gatt.device).isEmpty()) {
+                resetPeripheralState(gatt.device.address)
+            }
         }
-        
+
         fun gattsForDevice(device: BluetoothDevice): List<BluetoothGatt> =
             gatts.filter { it.device.address == device.address }
-        
+
+        /**
+         * Append a GATT operation to this gatt's serialized FIFO queue. Android allows only one GATT
+         * operation in flight per connection; a second issued before the first's callback returns is
+         * silently dropped. The queue dispatches one at a time and advances from the matching callback
+         * (or a timeout), so descriptor writes can no longer race service discovery / MTU / each other.
+         */
+        fun enqueueOperation(
+            gatt: BluetoothGatt,
+            type: GattOperationType,
+            label: String,
+            identity: String? = null,
+            action: (BluetoothGatt) -> Boolean
+        ) {
+            synchronized(gattLock) {
+                // Don't (re)create a queue for a gatt that has already been forgotten; that would both
+                // leak the queue and dispatch onto a dead connection.
+                if (gatts.none { it === gatt }) {
+                    logger?.debug("Skipping GATT op '$label' — gatt for ${gatt.device.address} is no longer tracked")
+                    return
+                }
+                operationQueues
+                    .computeIfAbsent(gatt) { GattOperationQueue(it) }
+                    .enqueue(GattOperation(type, label, identity, action))
+            }
+        }
+
+        private fun completeOperation(gatt: BluetoothGatt, type: GattOperationType, identity: String? = null) {
+            operationQueues[gatt]?.complete(type, identity)
+        }
+
         fun scheduleDisconnectTimeout(gatt: BluetoothGatt) {
             val address = gatt.device.address
             cancelDisconnectTimeout(address)
             val timeoutRunnable = Runnable {
                 pendingTimeouts.remove(address)
-                if (gatts.contains(gatt)) {
-                    logger?.warn("Disconnect timeout for $address — forcing close")
-                    gatts.remove(gatt)
-                    gatt.close()
+                synchronized(gattLock) {
+                    if (gatts.contains(gatt)) {
+                        logger?.warn("Disconnect timeout for $address — forcing close")
+                        closeAndForget(gatt)
+                    }
                 }
             }
             pendingTimeouts[address] = timeoutRunnable
             disconnectHandler.postDelayed(timeoutRunnable, DISCONNECT_TIMEOUT_MS)
         }
-        
+
         private fun cancelDisconnectTimeout(address: String) {
             pendingTimeouts.remove(address)?.let { disconnectHandler.removeCallbacks(it) }
         }
-        
-        fun disconnectAllOnAdapterOff() {
+
+        fun disconnectAllOnAdapterOff() = synchronized(gattLock) {
             pendingTimeouts.keys.toList().forEach { cancelDisconnectTimeout(it) }
-            val connectedGatts = gatts.toList()
-            gatts.clear()
-            connectedGatts.forEach { gatt ->
+            gatts.toList().forEach { gatt ->
                 logger?.info("Adapter off - forcing disconnect for ${gatt.device.address}")
-                gatt.close()
+                closeAndForget(gatt)
             }
         }
         
@@ -480,48 +622,58 @@ class AndroidEngine(
                     logger?.info("Connected to ${device.address}")
                     addGatt(gatt)
                     if (autoDiscoverAllServicesAndCharacteristics) {
-                        gatt.readRemoteRssi()
-                        gatt.discoverServices()
+                        // Serialize the post-connect service discovery and RSSI read; issued back to
+                        // back without a queue, the second would race the first and be dropped.
+                        // Discovery is enqueued first because it is the critical path consumers gate
+                        // subscription work on — the best-effort RSSI read must not sit ahead of it,
+                        // or a dropped RSSI callback would stall discovery for the full op watchdog.
+                        enqueueOperation(gatt, GattOperationType.DISCOVER_SERVICES, "discoverServices") {
+                            it.discoverServices()
+                        }
+                        enqueueOperation(gatt, GattOperationType.READ_RSSI, "readRemoteRssi") {
+                            it.readRemoteRssi()
+                        }
                     }
                 } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                     logger?.info("Disconnected from ${device.address}")
-                    cancelDisconnectTimeout(device.address)
-                    gatts.remove(gatt)
-                    gatt.close()
+                    // closeAndForget removes/closes the gatt, clears its queue, and resets the reused
+                    // peripheral's transient state so a later reconnect waits for the new connection's
+                    // discovery/MTU instead of reading stale values — but only if no newer gatt for this
+                    // address is already tracked (reconnect race).
+                    closeAndForget(gatt)
                 }
             }
         }
         
         override fun onServicesDiscovered(gatt: BluetoothGatt?, status: Int) {
             logger?.info("onServicesDiscovered status=$status")
+            // Advance the queue regardless of status so a failed discovery does not stall it.
+            gatt?.let { completeOperation(it, GattOperationType.DISCOVER_SERVICES) }
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 logger?.error("Service discovery failed with status $status")
                 return
             }
             gatt?.device?.let { device ->
-                gatt.services.let { services ->
-                    val peripheral = _peripherals.value.find { (it as? AndroidBluetoothPeripheral)?.device?.address == device.address }
-                    (peripheral as? AndroidBluetoothPeripheral)?._servicesFlow?.value =
-                        services.map { AndroidBluetoothService(it) }
-                }
+                peripheralFor(device.address)?._servicesFlow?.value =
+                    gatt.services.map { AndroidBluetoothService(it) }
             }
         }
         
         override fun onMtuChanged(gatt: BluetoothGatt?, mtu: Int, status: Int) {
             logger?.debug("onMtuChanged mtu=$mtu status=$status")
+            gatt?.let { completeOperation(it, GattOperationType.MTU) }
             gatt?.device?.let { device ->
                 if (status == BluetoothGatt.GATT_SUCCESS) {
-                    val peripheral = _peripherals.value.find { (it as? AndroidBluetoothPeripheral)?.device?.address == device.address }
-                    (peripheral as? AndroidBluetoothPeripheral)?.mtuSize = mtu
+                    peripheralFor(device.address)?.mtuSize = mtu
                 }
             }
         }
         
         override fun onReadRemoteRssi(gatt: BluetoothGatt?, rssi: Int, status: Int) {
             logger?.debug("onReadRemoteRssi $rssi")
+            gatt?.let { completeOperation(it, GattOperationType.READ_RSSI) }
             gatt?.device?.let { device ->
-                val peripheral = _peripherals.value.find { (it as? AndroidBluetoothPeripheral)?.device?.address == device.address }
-                (peripheral as? AndroidBluetoothPeripheral)?.rssi = rssi.toFloat()
+                peripheralFor(device.address)?.rssi = rssi.toFloat()
             }
         }
         
@@ -531,6 +683,7 @@ class AndroidEngine(
             status: Int
         ) {
             logger?.debug("onCharacteristicRead ${characteristic?.uuid} status=$status")
+            gatt?.let { completeOperation(it, GattOperationType.READ_CHAR, characteristic?.uuid?.toString()) }
         }
         
         override fun onCharacteristicChanged(
@@ -541,9 +694,7 @@ class AndroidEngine(
             if (gatt == null || characteristic == null) return
 
             val value = characteristic.value?.copyOf() ?: return
-            val peripheral =
-                _peripherals.value.find { (it as? AndroidBluetoothPeripheral)?.device?.address == gatt.device.address }
-                    ?: AndroidBluetoothPeripheral(gatt.device)
+            val peripheral = peripheralFor(gatt.device.address) ?: AndroidBluetoothPeripheral(gatt.device)
             val bluetoothCharacteristic = AndroidBluetoothCharacteristic(characteristic)
             bluetoothCharacteristic.emitNotification(value)
             _characteristicNotifications.tryEmit(
@@ -561,26 +712,144 @@ class AndroidEngine(
             status: Int
         ) {
             logger?.debug("onCharacteristicWrite ${characteristic?.uuid} status=$status")
+            gatt?.let { completeOperation(it, GattOperationType.WRITE_CHAR, characteristic?.uuid?.toString()) }
         }
-        
+
         override fun onDescriptorRead(
             gatt: BluetoothGatt?,
             descriptor: BluetoothGattDescriptor?,
             status: Int
         ) {
             logger?.debug("onDescriptorRead ${descriptor?.uuid}")
+            gatt?.let { completeOperation(it, GattOperationType.READ_DESC, descriptor?.uuid?.toString()) }
         }
-        
+
         override fun onDescriptorWrite(
             gatt: BluetoothGatt?,
             descriptor: BluetoothGattDescriptor?,
             status: Int
         ) {
             logger?.debug("onDescriptorWrite ${descriptor?.uuid} status=$status")
+            gatt?.let { completeOperation(it, GattOperationType.WRITE_DESC, descriptor?.uuid?.toString()) }
+        }
+
+        /**
+         * Per-connection FIFO that serializes GATT operations. Android permits only one operation in
+         * flight per connection; the queue dispatches one at a time and advances when the matching
+         * callback fires (via [complete]) or a watchdog timeout elapses, so an operation can never be
+         * silently dropped by colliding with an in-flight one.
+         */
+        private inner class GattOperationQueue(private val gatt: BluetoothGatt) {
+            private val pending = ArrayDeque<GattOperation>()
+            private var current: GattOperation? = null
+            private val handler = Handler(Looper.getMainLooper())
+            private var timeout: Runnable? = null
+
+            @Synchronized
+            fun enqueue(operation: GattOperation) {
+                pending.addLast(operation)
+                if (current == null) dispatchNext()
+            }
+
+            @Synchronized
+            fun complete(type: GattOperationType, identity: String?) {
+                val op = current ?: return
+                // Type matching guards against spurious/out-of-band callbacks (e.g. a system-initiated
+                // MTU change) advancing the wrong operation; a genuine mismatch simply leaves the
+                // current op pending until its own callback or the watchdog fires.
+                if (op.type != type) return
+                // When both the op and the callback target a specific resource (characteristic/
+                // descriptor), require the UUIDs to match too. Without this, a same-type callback that
+                // arrives after the watchdog already advanced the queue (e.g. a delayed onDescriptorWrite
+                // landing once the next WRITE_DESC is current) would finish the wrong operation and let
+                // the one after it be dispatched onto a still-busy connection and silently dropped.
+                if (op.identity != null && identity != null && op.identity != identity) return
+                finish(op)
+            }
+
+            @Synchronized
+            fun clear() {
+                timeout?.let { handler.removeCallbacks(it) }
+                timeout = null
+                current = null
+                pending.clear()
+            }
+
+            @Synchronized
+            private fun dispatchNext() {
+                if (current != null) return
+                while (true) {
+                    val op = pending.removeFirstOrNull() ?: return
+                    current = op
+                    val accepted = try {
+                        op.action(gatt)
+                    } catch (e: Exception) {
+                        logger?.error("GATT operation '${op.label}' threw: ${e.message}", e)
+                        false
+                    }
+                    if (accepted) {
+                        val watchdog = Runnable {
+                            logger?.warn("GATT operation '${op.label}' timed out after ${GATT_OPERATION_TIMEOUT_MS}ms")
+                            onTimeout(op)
+                        }
+                        timeout = watchdog
+                        handler.postDelayed(watchdog, GATT_OPERATION_TIMEOUT_MS)
+                        return
+                    }
+                    // The stack rejected the call outright (no callback will arrive); skip to the next.
+                    logger?.warn("GATT operation '${op.label}' was rejected by the stack; skipping")
+                    current = null
+                }
+            }
+
+            @Synchronized
+            private fun onTimeout(op: GattOperation) {
+                if (current === op) finish(op)
+            }
+
+            @Synchronized
+            private fun finish(op: GattOperation) {
+                if (current !== op) return
+                timeout?.let { handler.removeCallbacks(it) }
+                timeout = null
+                current = null
+                dispatchNext()
+            }
         }
     }
-    
+
     companion object {
         private const val DISCONNECT_TIMEOUT_MS = 5_000L
+
+        /**
+         * Watchdog timeout for a single in-flight GATT operation. If its callback never arrives (the
+         * stack occasionally drops one), the queue advances after this delay rather than stalling
+         * forever. Comfortably longer than any normal read/write/discover/MTU exchange.
+         */
+        private const val GATT_OPERATION_TIMEOUT_MS = 10_000L
     }
 }
+
+private enum class GattOperationType {
+    DISCOVER_SERVICES,
+    MTU,
+    READ_RSSI,
+    READ_CHAR,
+    WRITE_CHAR,
+    READ_DESC,
+    WRITE_DESC
+}
+
+private class GattOperation(
+    val type: GattOperationType,
+    val label: String,
+    /**
+     * Resource UUID this operation targets (characteristic/descriptor), or null for connection-wide
+     * operations (discover/MTU/RSSI). When both this and a completion callback carry an identity, the
+     * queue requires them to match before advancing, so a late or stray same-type callback cannot
+     * finish a different operation. See [AndroidEngine.GattClientCallback.GattOperationQueue.complete].
+     */
+    val identity: String? = null,
+    /** Issues the underlying GATT call; returns the stack's accepted/false result. */
+    val action: (BluetoothGatt) -> Boolean
+)

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -10,11 +10,11 @@ org.gradle.configureondemand = false
 android.useAndroidX=true
 android.enableJetifier=true
 
-version=3.4.4
-versionCore=3.4.4
-versionEngines=3.4.4
-versionPlugins=3.4.4
-versionLegacy=3.4.4
+version=3.4.5
+versionCore=3.4.5
+versionEngines=3.4.5
+versionPlugins=3.4.5
+versionLegacy=3.4.5
 group=dev.bluefalcon
 libraryName=blue-falcon
 kotlinx_coroutines_version=1.11.0


### PR DESCRIPTION
## Problem

On Android, indications/notifications were silently dropped when a consumer disconnected and then reconnected to the **same reused `BluetoothPeripheral` instance** within one process. The first connect after process start always worked; only reconnects failed.

Two root causes combined:

1. **Stale per-connection state.** A reused `AndroidBluetoothPeripheral` kept the previous connection's discovered services (`_servicesFlow`) and negotiated `mtuSize` across disconnect — they were never reset. On reconnect, a consumer that waits for "services discovered" / "MTU negotiated" before subscribing was satisfied *instantly* by the stale values, while the new `BluetoothGatt` was still running `discoverServices()`.
2. **No GATT operation serialization.** Android allows only one GATT operation in flight per connection; a second issued before the first's callback returns is silently dropped. The engine issued every op fire-and-forget, so the CCC `writeDescriptor` from `notify`/`indicateCharacteristic` raced the in-flight `discoverServices()` and was dropped — the peripheral never saw the subscription.

## Changes

- **Reset transient state on disconnect + connect.** `AndroidBluetoothPeripheral.resetConnectionState()` clears `_servicesFlow`/`mtuSize`; invoked on every disconnect path (`STATE_DISCONNECTED`, force-close watchdog, adapter-off) and at the start of `connect()` (covers a delayed/missing disconnect callback). `rssi` is preserved (also populated from scan results).
- **Per-connection serialized FIFO (`GattOperationQueue`).** Dispatches one GATT op at a time and advances from the matching callback or a 10s watchdog. Every engine GATT call — discover/read/write/MTU/CCC write/post-connect RSSI+discover — goes through it, so a CCC write can no longer race discovery.
- **Deterministic gatt replacement on reconnect.** `addGatt` closes and replaces a stale same-address gatt so a fast reconnect can't strand operations on a dead connection; all gatt-lifecycle bookkeeping is serialized under one lock.
- **Payload snapshots.** Write payloads are `copyOf()`'d at enqueue time so deferring a write to dispatch can't transmit bytes a caller mutated meanwhile.
- Queue completions match on the resource UUID (not just op type), service discovery is enqueued ahead of the best-effort RSSI read, and `mtuSize`/`rssi` are `@Volatile` (written from binder-thread callbacks, cleared on the main thread).

## Compatibility

No public API changes. `minSdk` unchanged (24). Library version bumped 3.4.4 → 3.4.5.

## Testing

Compiles (`:engines:android:compileReleaseKotlinAndroid`). The reconnect path is best validated on-device: connect → enable indications → disconnect → reconnect (same instance) → enable indications again, repeated across several disconnect/reconnect cycles, confirming the peripheral receives the CCC write each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
