### PR TITLE
fix(android): close orphaned connectGatt so a never-established direct connect can't leak

### DIFF
--- a/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidEngine.kt
+++ b/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidEngine.kt
@@ -142,8 +142,8 @@ class AndroidEngine(
         // wedge it (it stops completing any new connection until power-cycled). Registering here lets
         // the next connect()/disconnect() tear the orphan down, so at most one initiation is ever
         // outstanding per address.
-gatt?.let { gattCallback.trackConnecting(it) }
-    ?: logger?.warn("connectGatt returned null for ${androidPeripheral.device.address}")
+        gatt?.let { gattCallback.trackConnecting(it) }
+            ?: logger?.warn("connectGatt returned null for ${androidPeripheral.device.address}")
     }
 
     private fun peripheralFor(address: String): AndroidBluetoothPeripheral? =

--- a/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidEngine.kt
+++ b/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidEngine.kt
@@ -133,7 +133,18 @@ class AndroidEngine(
         // are normally the same object, but a re-scan can produce a fresh instance.
         androidPeripheral.resetConnectionState()
         resetPeripheralState(androidPeripheral.device.address)
-        androidPeripheral.device.connectGatt(context, autoConnect, gattCallback, transportMethod)
+        val gatt = androidPeripheral.device.connectGatt(context, autoConnect, gattCallback, transportMethod)
+        // Track the returned handle IMMEDIATELY, not only once it reaches STATE_CONNECTED. A direct
+        // (autoConnect=false) connect that never establishes never fires onConnectionStateChange, so
+        // without this it would never enter [gatts] — meaning neither disconnect() nor a later
+        // connect() could ever close it, and the Android stack keeps initiating it for ~30 s. Against
+        // a peripheral that accepts only one connection, several such orphaned initiations overlap and
+        // wedge it (it stops completing any new connection until power-cycled). Registering here lets
+        // the next connect()/disconnect() tear the orphan down, so at most one initiation is ever
+        // outstanding per address.
+        if (gatt != null) {
+            gattCallback.trackConnecting(gatt)
+        }
     }
 
     private fun peripheralFor(address: String): AndroidBluetoothPeripheral? =
@@ -519,6 +530,23 @@ class AndroidEngine(
         // is always gattLock -> queue monitor; no path takes them the other way, so there is no
         // deadlock with [GattOperationQueue]'s per-instance synchronization.
         private val gattLock = Any()
+
+        /**
+         * Register a freshly issued connectGatt handle before it reaches STATE_CONNECTED, closing any
+         * earlier handle for the same address first. This is the in-flight counterpart to [addGatt]
+         * (which only runs once a connection is actually established): it guarantees that an orphaned
+         * direct-connect — one that never establishes and therefore never produces a callback — is
+         * still tracked, so the next connect()/disconnect() can close it. Without it those orphaned
+         * initiations accumulate and wedge a single-connection peripheral.
+         */
+        fun trackConnecting(gatt: BluetoothGatt) = synchronized(gattLock) {
+            val address = gatt.device.address
+            gatts.filter { it.device.address == address && it !== gatt }
+                .forEach { closeAndForget(it) }
+            if (gatts.none { it === gatt }) {
+                gatts.add(gatt)
+            }
+        }
 
         private fun addGatt(gatt: BluetoothGatt) = synchronized(gattLock) {
             // Replace any stale same-address gatt from a previous connection. On a fast reconnect the

--- a/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidEngine.kt
+++ b/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidEngine.kt
@@ -142,9 +142,8 @@ class AndroidEngine(
         // wedge it (it stops completing any new connection until power-cycled). Registering here lets
         // the next connect()/disconnect() tear the orphan down, so at most one initiation is ever
         // outstanding per address.
-        if (gatt != null) {
-            gattCallback.trackConnecting(gatt)
-        }
+gatt?.let { gattCallback.trackConnecting(it) }
+    ?: logger?.warn("connectGatt returned null for ${androidPeripheral.device.address}")
     }
 
     private fun peripheralFor(address: String): AndroidBluetoothPeripheral? =


### PR DESCRIPTION
## Problem

`AndroidEngine.connect()` calls `device.connectGatt(context, autoConnect = false, gattCallback, transportMethod)` and **discards the returned `BluetoothGatt`**. A gatt is only entered into the engine's `gatts` list (via `addGatt`) from `onConnectionStateChange(STATE_CONNECTED)`.

So a **direct (`autoConnect = false`) connect that never establishes is never tracked**:
- `disconnect()` iterates `gattsForDevice(device)` → empty → no-op for it.
- a later `connect()` has no handle to it either.

The Android stack therefore keeps **initiating that orphaned connection for ~30 s** (the direct-connect timeout). Against a peripheral that accepts only one connection (`CONFIG_BT_MAX_CONN = 1` on the ESP32-C3 we hit this on), several orphaned initiations from successive attempts **overlap and wedge the peripheral** — it stops completing *any* new connection until it is power-cycled. A central toggle does not recover it; only a peripheral reset does.

This reproduces the field signature of an intermittent ~10–30% per-attempt establishment failure that worsens/clusters within a session: the orphan is born from the first *slow* establishment, which is frequent at marginal RF and rare at point-blank, so the onset is highly variable.

## Fix

Retain the `connectGatt` handle and register it immediately via a new `GattClientCallback.trackConnecting(gatt)`, which closes any prior gatt for the same address and tracks the new one **before** `STATE_CONNECTED`. At most one initiation is ever outstanding per address; an orphaned/never-established direct connect is always torn down by the next `connect()`/`disconnect()`. `addGatt` (on `STATE_CONNECTED`) is now idempotent with it.

## Validation (on hardware)

ESP32-C3 peripheral (`CONFIG_BT_MAX_CONN = 1`), Fire Max 11 central, single-attempt connect→discover→disconnect loop, identical RF and cadence:

| build | N | result |
|---|---|---|
| stock | 40 | clean to ~iter 27, then a **permanent wedge** (every later connect fails; only a peripheral power-cycle recovers) |
| **patched** | 40 / 100 / 100 | **40/40, 100/100, 100/100 — clean** |
| minimal raw `BluetoothGatt` control (always `close()`s) | 40 / 100 | clean (matches the patched engine) |

The patched engine is statistically indistinguishable from a minimal correct `BluetoothGatt` central.