### PR TITLE
fix: iOS characteristic notifications silently dropped after reconnect

### DIFF
--- a/library/engines/apple-shared/src/appleMain/kotlin/dev/bluefalcon/engine/apple/AppleEngine.kt
+++ b/library/engines/apple-shared/src/appleMain/kotlin/dev/bluefalcon/engine/apple/AppleEngine.kt
@@ -587,11 +587,12 @@ class AppleEngine : BlueFalconEngine, CBCentralManagerCallback, CBPeripheralCall
         error: NSError?
     ) {
         if (error != null) return
-        if (!nativeConnectionOwnership.isActive(
-                peripheral.identifier.UUIDString,
-                peripheral,
-            )
-        ) {
+        // Gate on the UUID-tracked connection (not referential equality of the CBPeripheral
+        // instance) to stay consistent with activeConnection(). CoreBluetooth can hand back a
+        // different CBPeripheral wrapper for the same underlying device (e.g. after a
+        // reconnect via retrievePeripheralsWithIdentifiers), which previously caused valid
+        // notifications to be silently dropped on iOS.
+        if (connectedPeripherals[peripheral.identifier.UUIDString] == null) {
             return
         }
         val value = snapshotCallbackPayload(


### PR DESCRIPTION
## Summary
Fixes #246 — `blueFalcon.engine.characteristicNotifications` never emitted on iOS even though `notifyCharacteristic(notify = true)` succeeded.

## Root cause
`AppleEngine.onCharacteristicValueUpdated` gated notification delivery via `AppleNativeConnectionOwnership.isActive(uuid, peripheral)`, which requires **referential (`===`) equality** between the `CBPeripheral` instance registered at connect time and the instance CoreBluetooth passes to the `didUpdateValueForCharacteristic` delegate callback.

CoreBluetooth can hand back a different `CBPeripheral` wrapper for the same physical device (e.g. `connect()` re-resolving an already-connected peripheral via `retrievePeripheralsWithIdentifiers`, see #245). When that happens, the referential check silently fails and every incoming notification is dropped — with no error surfaced, since `setNotifyValue`/`notifyCharacteristic` had already completed successfully.

`activeConnection()` in the same class was already fixed in #245 to key off the peripheral's UUID instead of instance identity, but `onCharacteristicValueUpdated` was missed.

## Fix
Gate notification emission on `connectedPeripherals[uuid] != null`, consistent with `activeConnection()`, instead of the strict referential ownership check.

## Testing
- `./gradlew :engines:macos:compileKotlinMacosArm64` — compiles clean (only pre-existing unrelated warnings)
- `./gradlew :engines:macos:macosArm64Test` — all apple-shared/macos tests pass
