### PR TITLE
fix: Android ServiceFilter scan misses devices advertising via service data

### DIFF
--- a/library/core/src/commonMain/kotlin/dev/bluefalcon/core/BluetoothTypes.kt
+++ b/library/core/src/commonMain/kotlin/dev/bluefalcon/core/BluetoothTypes.kt
@@ -47,6 +47,26 @@ interface BluetoothPeripheral {
      */
     val manufacturerData: Map<Int, ByteArray>
         get() = emptyMap()
+
+    /**
+     * Service UUIDs advertised by this peripheral, gathered from every advertisement AD
+     * structure that carries a service UUID: the complete/incomplete service UUID list *and*
+     * the service data structure. Populated from scan results; empty when not advertised or
+     * not yet scanned.
+     *
+     * Many real-world devices (e.g. Xiaomi/Mi Home accessories) only advertise their service
+     * UUID inside the service-data AD structure rather than the service UUID list, so this is
+     * a superset of what a platform's native scan-filter UUID matching considers.
+     */
+    val advertisedServiceUUIDs: List<Uuid>
+        get() = emptyList()
+
+    /**
+     * Whether the peripheral's advertisement indicated it is connectable, or `null` when the
+     * platform/advertisement does not expose this information.
+     */
+    val isConnectable: Boolean?
+        get() = null
 }
 
 /**

--- a/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidBluetoothPeripheral.kt
+++ b/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidBluetoothPeripheral.kt
@@ -37,6 +37,12 @@ class AndroidBluetoothPeripheral(val device: BluetoothDevice) : BluetoothPeriphe
     @Volatile
     override var manufacturerData: Map<Int, ByteArray> = emptyMap()
 
+    @Volatile
+    override var advertisedServiceUUIDs: List<Uuid> = emptyList()
+
+    @Volatile
+    override var isConnectable: Boolean? = null
+
     /**
      * Clears transient per-connection state (discovered services and the negotiated MTU) so that a
      * later reconnect using this same reused instance does not observe stale values from the previous

--- a/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidEngine.kt
+++ b/library/engines/android/src/androidMain/kotlin/dev/bluefalcon/engine/android/AndroidEngine.kt
@@ -71,6 +71,11 @@ class AndroidEngine(
     
     override var isScanning: Boolean = false
         private set
+
+    // Filters requested via scan(); matching is performed in software in the scan callback -
+    // see the comment in scan() for why we don't rely on the native ScanFilter for this.
+    @Volatile
+    private var activeScanFilters: List<ServiceFilter> = emptyList()
     
     private val bluetoothManager: BluetoothManager =
         context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
@@ -119,18 +124,18 @@ class AndroidEngine(
     override suspend fun scan(filters: List<ServiceFilter>) {
         logger?.info("Starting scan with ${filters.size} filters")
         isScanning = true
-        
-        val scanFilters: List<ScanFilter> = if (filters.isEmpty()) {
-            listOf(ScanFilter.Builder().build())
-        } else {
-            filters.map { filter ->
-                val filterBuilder = ScanFilter.Builder()
-                val parcelUuid = android.os.ParcelUuid(java.util.UUID.fromString(filter.uuid.toString()))
-                filterBuilder.setServiceUuid(parcelUuid)
-                filterBuilder.build()
-            }
-        }
-        
+        activeScanFilters = filters
+
+        // Android's native ScanFilter.setServiceUuid() only matches the "complete/incomplete
+        // service UUID list" AD structure. Many real devices (e.g. Xiaomi/Mi Home accessories,
+        // which advertise 0000fe95-...) only put their service UUID in the "service data" AD
+        // structure instead, so a hardware-level ScanFilter silently drops them before they ever
+        // reach our callback - see https://github.com/Reedyuk/blue-falcon/issues/222. To match the
+        // more lenient behaviour of CoreBluetooth (macOS/iOS) we always scan unfiltered at the
+        // platform level and apply [ServiceFilter] matching in software against every advertised
+        // service UUID we can observe (see [matchesActiveFilters]).
+        val scanFilters: List<ScanFilter> = listOf(ScanFilter.Builder().build())
+
         val settings = ScanSettings.Builder()
             .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
             .build()
@@ -764,21 +769,53 @@ class AndroidEngine(
         private fun addScanResult(result: ScanResult?) {
             logger?.debug("addScanResult $result")
             result?.device?.let { device ->
+                val advertisedServiceUUIDs = extractServiceUuids(result)
+                if (!matchesActiveFilters(advertisedServiceUUIDs)) return
                 val bluetoothPeripheral = AndroidBluetoothPeripheral(device)
                 val newRssi = result.rssi.toFloat()
                 bluetoothPeripheral.rssi = newRssi
                 bluetoothPeripheral.manufacturerData = extractManufacturerData(result)
+                bluetoothPeripheral.advertisedServiceUUIDs = advertisedServiceUUIDs
+                bluetoothPeripheral.isConnectable = extractConnectable(result)
                 val existing = _peripherals.value.find { it.uuid == bluetoothPeripheral.uuid }
                 if (existing != null) {
                     (existing as? AndroidBluetoothPeripheral)?.rssi = newRssi
                     (existing as? AndroidBluetoothPeripheral)?.manufacturerData =
                         bluetoothPeripheral.manufacturerData
+                    (existing as? AndroidBluetoothPeripheral)?.advertisedServiceUUIDs =
+                        bluetoothPeripheral.advertisedServiceUUIDs
+                    (existing as? AndroidBluetoothPeripheral)?.isConnectable =
+                        bluetoothPeripheral.isConnectable
                     _rssiUpdates.tryEmit(bluetoothPeripheral.uuid to newRssi)
                 } else {
                     _peripherals.value = _peripherals.value + setOf(bluetoothPeripheral)
                 }
             }
         }
+
+        /**
+         * Matches [ServiceFilter]s in software against every service UUID we can observe in the
+         * advertisement (service UUID list *and* service data), rather than relying on Android's
+         * native `ScanFilter`, which only inspects the service UUID list AD structure. See
+         * https://github.com/Reedyuk/blue-falcon/issues/222.
+         */
+        private fun matchesActiveFilters(advertisedServiceUUIDs: List<Uuid>): Boolean {
+            val filters = activeScanFilters
+            if (filters.isEmpty()) return true
+            return filters.any { it.uuid in advertisedServiceUUIDs }
+        }
+
+        private fun extractServiceUuids(result: ScanResult): List<Uuid> {
+            val scanRecord = result.scanRecord ?: return emptyList()
+            val fromServiceUuidList = scanRecord.serviceUuids?.map { it.uuid.toString().toUuid() }
+                ?: emptyList()
+            val fromServiceData = scanRecord.serviceData?.keys?.map { it.uuid.toString().toUuid() }
+                ?: emptyList()
+            return (fromServiceUuidList + fromServiceData).distinct()
+        }
+
+        private fun extractConnectable(result: ScanResult): Boolean? =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) result.isConnectable else null
 
         private fun extractManufacturerData(result: ScanResult): Map<Int, ByteArray> {
             val scanRecord = result.scanRecord ?: return emptyMap()


### PR DESCRIPTION
## Summary
Fixes #222 — `blueFalcon.scan(filters = listOf(ServiceFilter(...)))` returns no results on Android (works fine on macOS/JVM/desktop, and works on Android with no filter).

## Root cause
`AndroidEngine.scan()` translated each `ServiceFilter` into a native `android.bluetooth.le.ScanFilter.setServiceUuid(...)`. That API only matches the advertisement's **complete/incomplete service UUID list** AD structure. Many real devices — including the Xiaomi/Mi Home accessory in the report, which advertises `0000fe95-0000-1000-8000-00805f9b34fb` — put their service UUID in the **service data** AD structure instead. The Android Bluetooth stack drops non-matching advertisements before they ever reach the app's scan callback, so those devices were invisible whenever a filter was applied, even though they show up fine with no filter (and on macOS, where CoreBluetooth is more lenient about where it looks for the service UUID).

## Fix
`AndroidEngine` now always scans unfiltered at the platform level and applies `ServiceFilter` matching **in software**, checking every service UUID it can observe in the advertisement — both the service UUID list *and* the service data keys. This mirrors the behaviour users already get on macOS/iOS.

## Bonus
The issue also asked for a couple of advertisement fields to be exposed publicly. Added to `BluetoothPeripheral` (default no-ops so other engines are unaffected) and implemented for Android, since that's the platform involved in this bug:
- `advertisedServiceUUIDs: List<Uuid>`
- `isConnectable: Boolean?`

(`manufacturerData`, the third field requested, already existed.)

## Testing
- `./gradlew :engines:android:compileDebugKotlinAndroid` — compiles clean
- `./gradlew :engines:android:testDebugUnitTest` — all existing Android engine unit tests pass
- `./gradlew :core:compileKotlinMetadata :engines:macos:compileKotlinMacosArm64 :engines:js:compileKotlinJs` — confirms the new default interface members don't break other engines
