### PR TITLE
Windows: reflect live adapter power state and remote disconnects

### DIFF
--- a/library/engines/windows/src/jvmMain/kotlin/dev/bluefalcon/engine/windows/WindowsEngine.kt
+++ b/library/engines/windows/src/jvmMain/kotlin/dev/bluefalcon/engine/windows/WindowsEngine.kt
@@ -329,6 +329,27 @@ class WindowsEngine : BlueFalconEngine {
     
     // Callbacks from native code
     @Suppress("unused")
+    private fun onAdapterStateChanged(ready: Boolean) {
+        _managerState.value = if (ready) BluetoothManagerState.Ready else BluetoothManagerState.NotReady
+    }
+
+    @Suppress("unused")
+    private fun onConnectionStateChanged(address: Long, state: Int) {
+        val peripheral = connections[address] ?: return
+        val newState = when (state) {
+            0 -> BluetoothPeripheralState.Disconnected
+            1 -> BluetoothPeripheralState.Connecting
+            2 -> BluetoothPeripheralState.Connected
+            3 -> BluetoothPeripheralState.Disconnecting
+            else -> BluetoothPeripheralState.Unknown
+        }
+        if (newState == BluetoothPeripheralState.Disconnected) {
+            connections.remove(address)
+        }
+        _connectionStateUpdates.tryEmit(ConnectionStateUpdate(peripheral, newState))
+    }
+
+    @Suppress("unused")
     private fun onDeviceDiscovered(
         address: Long,
         name: String?,

--- a/library/src/windowsMain/cpp/BluetoothLEManager.cpp
+++ b/library/src/windowsMain/cpp/BluetoothLEManager.cpp
@@ -11,6 +11,10 @@ BluetoothLEManager& BluetoothLEManager::getInstance() {
 
 BluetoothLEManager::~BluetoothLEManager() {
     stopScan();
+    if (m_radioStateChangedToken.value != 0 && m_bluetoothRadio != nullptr) {
+        m_bluetoothRadio.StateChanged(m_radioStateChangedToken);
+        m_radioStateChangedToken = event_token{};
+    }
     if (m_javaObject) {
         JNIEnv* env = nullptr;
         m_jvm->GetEnv((void**)&env, JNI_VERSION_1_6);
@@ -31,6 +35,110 @@ void BluetoothLEManager::initialize(JavaVM* jvm, jobject javaObject) {
     
     // Initialize WinRT
     init_apartment();
+
+    initializeRadioMonitoring();
+}
+
+void BluetoothLEManager::initializeRadioMonitoring() {
+    try {
+        // Find the first Bluetooth radio and subscribe to its power state so we can
+        // reflect the OS-level adapter on/off state as BluetoothManagerState, instead
+        // of only reporting Ready/NotReady once at native-library load time.
+        auto radiosOp = Radio::GetRadiosAsync();
+        radiosOp.Completed([this](auto&& asyncInfo, AsyncStatus status) {
+            if (status != AsyncStatus::Completed) return;
+            try {
+                auto radios = asyncInfo.GetResults();
+                for (auto radio : radios) {
+                    if (radio.Kind() == RadioKind::Bluetooth) {
+                        m_bluetoothRadio = radio;
+                        break;
+                    }
+                }
+                if (m_bluetoothRadio == nullptr) {
+                    notifyManagerStateChanged(false);
+                    return;
+                }
+
+                notifyManagerStateChanged(
+                    m_bluetoothRadio.State() == RadioState::On
+                );
+
+                m_radioStateChangedToken = m_bluetoothRadio.StateChanged(
+                    [this](Radio radio, auto&& args) {
+                        notifyManagerStateChanged(radio.State() == RadioState::On);
+                    });
+            } catch (...) {
+                notifyManagerStateChanged(false);
+            }
+        });
+    } catch (...) {
+        notifyManagerStateChanged(false);
+    }
+}
+
+void BluetoothLEManager::notifyManagerStateChanged(bool ready) {
+    m_lastReportedRadioReady = ready;
+
+    JNIEnv* env = nullptr;
+    if (m_jvm->AttachCurrentThread((void**)&env, nullptr) == JNI_OK) {
+        jclass cls = env->GetObjectClass(m_javaObject);
+        jmethodID mid = env->GetMethodID(cls, "onAdapterStateChanged", "(Z)V");
+        if (mid != nullptr) {
+            env->CallVoidMethod(m_javaObject, mid, (jboolean)ready);
+        }
+        env->DeleteLocalRef(cls);
+        m_jvm->DetachCurrentThread();
+    }
+}
+
+void BluetoothLEManager::notifyConnectionStateChanged(uint64_t address, int state) {
+    JNIEnv* env = nullptr;
+    if (m_jvm->AttachCurrentThread((void**)&env, nullptr) == JNI_OK) {
+        jclass cls = env->GetObjectClass(m_javaObject);
+        jmethodID mid = env->GetMethodID(cls, "onConnectionStateChanged", "(JI)V");
+        if (mid != nullptr) {
+            env->CallVoidMethod(m_javaObject, mid, (jlong)address, (jint)state);
+        }
+        env->DeleteLocalRef(cls);
+        m_jvm->DetachCurrentThread();
+    }
+}
+
+void BluetoothLEManager::subscribeToDeviceConnectionStatus(std::shared_ptr<DeviceConnection> connection) {
+    if (connection->device == nullptr) return;
+
+    uint64_t address = connection->address;
+    connection->connectionStatusChangedToken = connection->device.ConnectionStatusChanged(
+        [this, address](BluetoothLEDevice device, auto&& args) {
+            int newState;
+            if (device.ConnectionStatus() == BluetoothConnectionStatus::Connected) {
+                newState = 2; // Connected
+            } else {
+                newState = 0; // Disconnected
+            }
+
+            {
+                SRWLockGuard lock(&m_connectionsMutex);
+                auto it = m_connections.find(address);
+                if (it == m_connections.end()) return;
+                if (it->second->connectionState == newState) return;
+                it->second->connectionState = newState;
+                if (newState == 0) {
+                    // The remote device (or its own radio) dropped the link outside of
+                    // our own disconnect() call - e.g. the peripheral's Bluetooth was
+                    // turned off. Clear cached GATT state so a future connect() starts
+                    // clean, but keep the map entry removed only after notifying Java.
+                    if (it->second->device != nullptr) {
+                        it->second->device.ConnectionStatusChanged(
+                            it->second->connectionStatusChangedToken);
+                    }
+                    m_connections.erase(it);
+                }
+            }
+
+            notifyConnectionStateChanged(address, newState);
+        });
 }
 
 void BluetoothLEManager::startScan(JNIEnv* env, jobjectArray serviceUuids) {
@@ -177,26 +285,31 @@ void BluetoothLEManager::connect(uint64_t address) {
     // Connect to device asynchronously
     auto asyncOp = BluetoothLEDevice::FromBluetoothAddressAsync(address);
     asyncOp.Completed([this, address](auto&& asyncInfo, AsyncStatus status) {
-        SRWLockGuard lock(&m_connectionsMutex);
-        auto it = m_connections.find(address);
-        if (it == m_connections.end()) return;
-        
-        if (status == AsyncStatus::Completed) {
-            try {
-                it->second->device = asyncInfo.GetResults();
-                it->second->connectionState = 2; // Connected
-                
-                // Notify Java
-                JNIEnv* env = nullptr;
-                if (m_jvm->AttachCurrentThread((void**)&env, nullptr) == JNI_OK) {
-                    // Connection successful - Java code will call discoverServices
-                    m_jvm->DetachCurrentThread();
+        std::shared_ptr<DeviceConnection> connectedConnection;
+        {
+            SRWLockGuard lock(&m_connectionsMutex);
+            auto it = m_connections.find(address);
+            if (it == m_connections.end()) return;
+
+            if (status == AsyncStatus::Completed) {
+                try {
+                    it->second->device = asyncInfo.GetResults();
+                    it->second->connectionState = 2; // Connected
+                    connectedConnection = it->second;
+                } catch (...) {
+                    m_connections.erase(it);
+                    return;
                 }
-            } catch (...) {
+            } else {
                 m_connections.erase(it);
+                return;
             }
-        } else {
-            m_connections.erase(it);
+        }
+
+        // Subscribe outside the lock so the callback (which re-acquires the lock)
+        // can never deadlock against this completion handler.
+        if (connectedConnection) {
+            subscribeToDeviceConnectionStatus(connectedConnection);
         }
     });
 }
@@ -210,6 +323,7 @@ void BluetoothLEManager::disconnect(uint64_t address) {
         
         // Close device
         if (it->second->device != nullptr) {
+            it->second->device.ConnectionStatusChanged(it->second->connectionStatusChangedToken);
             it->second->device.Close();
             it->second->device = nullptr;
         }

--- a/library/src/windowsMain/cpp/BluetoothLEManager.h
+++ b/library/src/windowsMain/cpp/BluetoothLEManager.h
@@ -8,6 +8,7 @@
 #include <winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h>
 #include <winrt/Windows.Devices.Bluetooth.Advertisement.h>
 #include <winrt/Windows.Devices.Enumeration.h>
+#include <winrt/Windows.Devices.Radios.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <string>
 #include <map>
@@ -22,6 +23,7 @@ using namespace Windows::Devices::Bluetooth;
 using namespace Windows::Devices::Bluetooth::GenericAttributeProfile;
 using namespace Windows::Devices::Bluetooth::Advertisement;
 using namespace Windows::Devices::Enumeration;
+using namespace Windows::Devices::Radios;
 
 // Forward declarations
 class BluetoothLEManager;
@@ -33,6 +35,7 @@ struct DeviceConnection {
     std::map<winrt::guid, GattDeviceService> services;
     std::map<winrt::guid, GattCharacteristic> characteristics;
     int connectionState; // 0=disconnected, 1=connecting, 2=connected, 3=disconnecting
+    event_token connectionStatusChangedToken;
 };
 
 // Singleton manager for Bluetooth LE operations
@@ -69,6 +72,10 @@ private:
     // Helper methods
     void callJavaMethod(const char* methodName, const char* signature, ...);
     uint64_t bluetoothAddressToUint64(uint64_t address);
+    void notifyConnectionStateChanged(uint64_t address, int state);
+    void subscribeToDeviceConnectionStatus(std::shared_ptr<DeviceConnection> connection);
+    void initializeRadioMonitoring();
+    void notifyManagerStateChanged(bool ready);
     
     // Advertisement watcher
     BluetoothLEAdvertisementWatcher m_watcher{nullptr};
@@ -82,4 +89,9 @@ private:
     // Device connections
     std::map<uint64_t, std::shared_ptr<DeviceConnection>> m_connections;
     SRWLOCK m_connectionsMutex = SRWLOCK_INIT;
+
+    // Bluetooth radio (adapter) state monitoring
+    Radio m_bluetoothRadio{nullptr};
+    event_token m_radioStateChangedToken;
+    bool m_lastReportedRadioReady = false;
 };


### PR DESCRIPTION
## Problem

On the Windows engine (JNI + WinRT), reported by @simonecerrato:
1. `blueFalcon.managerState` stayed `Ready` forever, even after disabling the Bluetooth adapter in Windows.
2. A connected peripheral's connection state stayed `Connected` forever, even after the remote device's Bluetooth was turned off (i.e. no local `disconnect()` call was made).

## Root cause

- `WindowsEngine`'s `managerState` was only set once, at native library load time, based purely on whether the native DLL loaded successfully — there was no subscription to the actual Windows Bluetooth radio power state.
- `BluetoothLEManager::connect()`'s WinRT completion handler set `connectionState = 2` (Connected) once and never subscribed to further connection status changes, so nothing updated state (or emitted `ConnectionStateUpdate`) when the link dropped outside of an explicit `disconnect()` call.

## Fix

- Subscribe to `Windows.Devices.Radios.Radio.StateChanged` for the Bluetooth radio and forward changes via a new `onAdapterStateChanged` JNI callback, which updates `WindowsEngine`'s `_managerState` (`Ready`/`NotReady`) reactively.
- Subscribe to `BluetoothLEDevice.ConnectionStatusChanged` per connected device and forward changes via a new `onConnectionStateChanged` JNI callback, which updates the tracked connection state and emits `ConnectionStateUpdate` (removing the connection from the tracking map on a real disconnect, same as an explicit `disconnect()` call).
- Properly unsubscribe from both event tokens on manager teardown / explicit disconnect to avoid dangling WinRT event registrations.

## Verification

- `:engines:windows:compileKotlinJvm` passes.
- The native C++/WinRT changes (`BluetoothLEManager.cpp`/`.h`) can't be compiled or hardware-tested from this (macOS) environment, since the Windows engine requires the Windows SDK/WinRT toolchain and real Bluetooth hardware — please verify on a Windows machine per `library/src/windowsMain/cpp/README.md`. The new code follows the same JNI-callback/WinRT-event patterns already used elsewhere in this file (e.g. `onDeviceDiscovered`, `onServicesDiscovered`).

Closes the two issues raised about `managerState` and stale connection state on Windows.