### PR TITLE
Add structured peripheral connection state machine and fix retry plugin

### DIFF
--- a/docs/adr/0008-structured-peripheral-connection-state-machine.md
+++ b/docs/adr/0008-structured-peripheral-connection-state-machine.md
@@ -1,0 +1,204 @@
+# ADR 0008: Structured Per-Peripheral Connection State Machine
+
+**Status:** Proposed
+
+**Date:** 2026-08-27
+
+**Deciders:** Blue Falcon maintainers and community contributors
+
+**Technical Story:** Consumers must stitch together `connectionStateUpdates`, `serviceDiscoveryUpdates`,
+and a racy `connectionState()` poll to know when a peripheral is actually usable, and have no
+typed information about *why* a peripheral disconnected.
+
+## Context
+
+Blue Falcon's core (`BlueFalcon`/`BlueFalconEngine`) already exposes low-level, reactive
+connection primitives:
+
+- `BluetoothPeripheralState` — a flat enum (`Connecting`, `Connected`, `Disconnected`,
+  `Disconnecting`, `Unknown`).
+- `connectionStateUpdates: SharedFlow<ConnectionStateUpdate>` — emits transitions, but as a
+  `SharedFlow` with no replay: a collector that subscribes after a peripheral has already
+  connected sees nothing until the *next* transition.
+- `connectionState(peripheral): BluetoothPeripheralState` — a synchronous poll. Its own KDoc
+  warns it is racy immediately after calling `connect()`, because the platform connect callback
+  is asynchronous.
+- `serviceDiscoveryUpdates: SharedFlow<ServiceDiscoveryUpdate>` — a **separate** flow reporting
+  `ServicesDiscovered` / `CharacteristicsDiscovered` phases, decoupled from connection state.
+
+To know "is this peripheral connected *and* ready to have characteristics read/written",
+consumers must manually combine two independent flows, track per-peripheral bookkeeping
+themselves, and re-derive it from scratch in every app. There is also no typed signal for *why*
+a peripheral disconnected (user-initiated vs. a failed connect attempt vs. an unexpected drop),
+which apps need to decide whether to reconnect, and which would let a future retry policy (e.g.
+`blue-falcon-plugin-retry`) make smarter decisions.
+
+## Decision
+
+We will introduce a typed, per-peripheral connection state machine, derived entirely inside
+`BlueFalcon` (the core orchestration layer) by folding the *existing* `connectionStateUpdates`
+and `serviceDiscoveryUpdates` engine flows plus the outcome of `connect()`/`disconnect()` calls.
+No `BlueFalconEngine` or platform implementation changes are required — this is purely an
+additive layer on top of signals engines already emit.
+
+### New types (`core/PeripheralConnectionState.kt`)
+
+```kotlin
+sealed class PeripheralConnectionState {
+    data class Disconnected(val reason: DisconnectReason? = null) : PeripheralConnectionState()
+    object Connecting : PeripheralConnectionState()
+    object Connected : PeripheralConnectionState()   // connected, GATT service table not yet populated
+    object Ready : PeripheralConnectionState()        // connected AND services discovered
+    object Disconnecting : PeripheralConnectionState()
+}
+
+sealed class DisconnectReason {
+    object UserInitiated : DisconnectReason()   // disconnect() was called by the app
+    data class ConnectFailed(val cause: Throwable) : DisconnectReason() // connect() itself failed
+    object Unexpected : DisconnectReason()      // dropped while Connected/Ready, cause unknown to core
+}
+```
+
+`Ready` reflects only that the GATT **service** table is populated (the
+`ServiceDiscoveryPhase.ServicesDiscovered` event), not that every characteristic for every
+service has been discovered — consumers choose which services they care about and call
+`discoverCharacteristics` themselves, exactly as they do today via `serviceDiscoveryUpdates`.
+Claiming a fuller "everything discovered" state would require guessing consumer intent, so we
+deliberately keep `Ready`'s contract narrow and honest. A `Discovering` state was considered and
+rejected — see Alternatives.
+
+### New `BlueFalcon` API
+
+```kotlin
+val connectionStates: StateFlow<Map<String, PeripheralConnectionState>>   // keyed by peripheral.uuid
+
+fun peripheralState(peripheral: BluetoothPeripheral): PeripheralConnectionState // synchronous, current value
+
+fun connectionStateFlow(peripheral: BluetoothPeripheral): StateFlow<PeripheralConnectionState>
+```
+
+`connectionStateFlow` is a `StateFlow` (not `SharedFlow`): new collectors immediately observe the
+current state, eliminating the "subscribed after the event fired" race that `connectionState()`'s
+KDoc already warns about. It is derived via `.map { }.stateIn(engine.scope, Eagerly, ...)` over
+the shared `connectionStates` map — no manual locking, consistent with how the rest of the
+codebase (`characteristicWriteCapabilities`, `peripherals`) already exposes `StateFlow`s.
+
+### State derivation rules
+
+- `connect()` sets `Connecting` immediately; if the underlying `engine.connect()` call throws
+  synchronously (surfaced today as `Result.failure` from `interceptConnect`), state becomes
+  `Disconnected(ConnectFailed(cause))` right away without waiting for an engine event.
+- The real `Connected` / `Disconnected` transitions still come from `connectionStateUpdates`,
+  since — as the existing docs note — a successful `engine.connect()` call only means the
+  request was issued, not that the link is up.
+- `disconnect()` sets `Disconnecting` before invoking `engine.disconnect()`.
+- When a `Disconnected` event arrives from `connectionStateUpdates`, the **previous** state
+  decides the reason: previous `Disconnecting` → `UserInitiated`; previous `Connecting` →
+  `ConnectFailed` (belt-and-braces for engines that signal async connect failures this way
+  instead of throwing); previous `Connected`/`Ready` → `Unexpected`.
+- A `ServiceDiscoveryUpdate(phase = ServicesDiscovered)` event flips `Connected` → `Ready`.
+  `CharacteristicsDiscovered` events do not change state (see above).
+- Existing `connectionStateUpdates`, `serviceDiscoveryUpdates`, and `connectionState()` are
+  untouched — this is purely additive.
+
+## Consequences
+
+### Positive
+
+- Single, typed source of truth for "is this peripheral usable right now", replacing manual
+  flow-stitching in every consuming app.
+- `StateFlow` semantics remove the subscribe-after-the-fact race that today's docs merely warn
+  about instead of solving.
+- Typed `DisconnectReason` gives apps (and future plugins, e.g. retry policies) a basis for
+  deciding whether to reconnect.
+- Zero engine/platform changes — works identically on every existing `BlueFalconEngine`
+  implementation (Android, Apple, JS, Windows, RPi) the moment it's merged into core.
+- Fully additive/non-breaking: existing `connectionState()`, `connectionStateUpdates`, and
+  `serviceDiscoveryUpdates` APIs are unchanged.
+
+### Negative
+
+- `Unexpected` disconnects carry no platform error code/cause in this iteration, since
+  `ConnectionStateUpdate` doesn't carry one today. A follow-up ADR could extend
+  `ConnectionStateUpdate` with an optional cause per engine to enrich this further.
+- `Ready` only guarantees service-level discovery, not characteristics — consumers who assumed a
+  hypothetical fuller state must still branch on `serviceDiscoveryUpdates` for characteristics,
+  same as today.
+- One more piece of state maintained per peripheral for the lifetime of the `BlueFalcon`
+  instance (small memory cost, cleared via `clearPeripherals()`/explicit removal — see
+  Implementation Notes).
+
+### Neutral
+
+- Adds one new source file and modest additions to `BlueFalcon.kt`; no new Gradle module or
+  plugin required since this lives in `core`.
+
+## Alternatives Considered
+
+### Alternative 1: Add a `Discovering` intermediate state
+
+Model the time between `Connected` and `Ready` as an explicit `Discovering` state.
+
+**Pros:**
+- Slightly more granular for UI spinners.
+
+**Cons:**
+- There is no distinct engine signal for "discovery started" separate from `Connected` itself
+  (auto-discovery is simply triggered internally by engines immediately after connecting) — the
+  state would be inferred purely from elapsed time, not a real event, which is misleading.
+
+**Why not chosen:** Would fabricate precision the underlying signals don't actually provide.
+
+### Alternative 2: Change `connectionState()`'s return type in place
+
+Widen the existing `connectionState(peripheral): BluetoothPeripheralState` to return the new
+sealed state directly instead of adding new API surface.
+
+**Pros:**
+- One connection-state API instead of two.
+
+**Cons:**
+- Breaking change for every existing consumer and platform sample pattern-matching on
+  `BluetoothPeripheralState`.
+
+**Why not chosen:** Violates the additive/non-breaking approach used by every prior ADR in this
+series (e.g. ADR 0004's notification events were added alongside existing delegates, not in
+place of them).
+
+### Alternative 3: Implement per-engine instead of in core
+
+Have each `BlueFalconEngine` (Android, Apple, JS, Windows, RPi) compute and expose its own
+`PeripheralConnectionState`.
+
+**Pros:**
+- Engines could enrich `Unexpected`/`ConnectFailed` with real platform error codes immediately.
+
+**Cons:**
+- Six independent implementations to write, test, and keep consistent instead of one.
+- Most of the derivation logic (folding two flows) is platform-agnostic and belongs in core.
+
+**Why not chosen:** Core-only implementation delivers the same value today with a fraction of the
+surface area; richer per-platform error causes can be layered in later without breaking this API
+(`ConnectFailed`/`Unexpected` are already open to carrying more data).
+
+## Implementation Notes
+
+- New file: `library/core/src/commonMain/kotlin/dev/bluefalcon/core/PeripheralConnectionState.kt`.
+- `BlueFalcon.kt` gains a `MutableStateFlow<Map<String, PeripheralConnectionState>>`, two
+  collectors launched in `init {}` (one per existing engine flow), and state transitions wired
+  into `connect()`/`disconnect()`.
+- No changes to `BlueFalconEngine`, `PluginRegistry`, or any platform engine implementation.
+- Tested via `FakeBlueFalconEngine`'s existing `emitConnectionStateUpdate` /
+  `emitServiceDiscoveryUpdate` test helpers — no new test infrastructure required.
+- Entries are not proactively evicted from the map when a peripheral disconnects (so
+  `Disconnected(reason)` remains inspectable); a future pass could add cleanup on
+  `clearPeripherals()` if memory growth across many transient peripherals becomes a concern.
+
+## Related Decisions
+
+- [ADR 0004: Expose Characteristic Notification Events to Consumers and Plugins](0004-expose-characteristic-notification-events.md)
+
+## References
+
+- `library/core/src/commonMain/kotlin/dev/bluefalcon/core/BluetoothStates.kt`
+- `library/core/src/commonMain/kotlin/dev/bluefalcon/core/BlueFalcon.kt`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,3 +63,4 @@ ADRs can have the following statuses:
 - [ADR 0005: BLE Device Cloning Plugin](0005-ble-device-cloning-plugin.md) - **Proposed** - 2026-05-15
 - [ADR 0006: BLE Device Broadcast Plugin](0006-ble-device-broadcast-plugin.md) - **Accepted** - 2026-05-15
 - [ADR 0007: Introduce a Production-Grade Peripheral/GATT Server Module](0007-introduce-production-grade-peripheral-module.md) - **Proposed** - 2026-07-16
+- [ADR 0008: Structured Per-Peripheral Connection State Machine](0008-structured-peripheral-connection-state-machine.md) - **Proposed** - 2026-08-27

--- a/examples/ComposeMultiplatform-3.0-Example/shared/build.gradle.kts
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 val falconVersion = "3.7.3"
+val peripheralVersion = "3.7.1"
 val coroutinesVersion = "1.11.0"
 
 kotlin {
@@ -55,7 +56,7 @@ kotlin {
 
                 // Blue Falcon 3.0
                 implementation("dev.bluefalcon:blue-falcon-core:$falconVersion")
-                implementation("dev.bluefalcon:blue-falcon-peripheral:$falconVersion")
+                implementation("dev.bluefalcon:blue-falcon-peripheral:$peripheralVersion")
                 implementation("dev.bluefalcon:blue-falcon-plugin-logging:$falconVersion")
                 implementation("dev.bluefalcon:blue-falcon-plugin-queue:$falconVersion")
                 implementation("dev.bluefalcon:blue-falcon-plugin-retry:$falconVersion")

--- a/examples/ComposeMultiplatform-3.0-Example/shared/src/commonMain/kotlin/com/example/bluefalconcomposemultiplatform/ble/presentation/BluetoothDeviceViewModel.kt
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/src/commonMain/kotlin/com/example/bluefalconcomposemultiplatform/ble/presentation/BluetoothDeviceViewModel.kt
@@ -1,7 +1,8 @@
 package com.example.bluefalconcomposemultiplatform.ble.presentation
 
 import dev.bluefalcon.core.BlueFalcon
-import dev.bluefalcon.core.BluetoothPeripheralState
+import dev.bluefalcon.core.DisconnectReason
+import dev.bluefalcon.core.PeripheralConnectionState
 import dev.bluefalcon.core.ServiceDiscoveryPhase
 import dev.bluefalcon.core.ServiceFilter
 import dev.bluefalcon.core.toUuid
@@ -111,21 +112,25 @@ class BluetoothDeviceViewModel(
             }
         }
 
-        // Collect connection state updates so the UI reflects actual BLE state.
-        // Do not rely on connectionState() polling after connect() — BLE connections are
-        // asynchronous and the state will still read Disconnected until this callback fires.
+        // Collect the structured per-peripheral connection state machine (ADR 0008) so the UI
+        // reflects actual BLE state, including synchronous connect failures that never emit a
+        // raw connectionStateUpdates event at all (engine.connect() throwing before any platform
+        // callback fires). This is a StateFlow, so it also derives an authoritative snapshot for
+        // every peripheral currently known to the UI on each emission - no polling required.
         viewModelScope.launch(Dispatchers.IO) {
-            blueFalcon.connectionStateUpdates.collect { update ->
-                val peripheralId = update.peripheral.uuid
-                val isNowConnected = update.state == BluetoothPeripheralState.Connected
+            blueFalcon.connectionStates.collect { states ->
                 _deviceState.update { state ->
                     val updatedDevices = state.devices.toMutableMap()
-                    updatedDevices[peripheralId]?.let { device ->
-                        // The connect/disconnect operation has resolved, so clear the
-                        // in-flight spinner regardless of the resulting connection state.
-                        updatedDevices[peripheralId] = device.copy(connected = isNowConnected, connecting = false)
+                    var changed = false
+                    state.devices.forEach { (peripheralId, device) ->
+                        val peripheralState = states[peripheralId] ?: return@forEach
+                        val updated = device.applyConnectionState(peripheralState)
+                        if (updated != device) {
+                            updatedDevices[peripheralId] = updated
+                            changed = true
+                        }
                     }
-                    state.copy(devices = HashMap(updatedDevices))
+                    if (changed) state.copy(devices = HashMap(updatedDevices)) else state
                 }
             }
         }
@@ -287,8 +292,11 @@ class BluetoothDeviceViewModel(
                     if (device.connected && device.peripheral.services.isEmpty()) {
                         viewModelScope.launch(Dispatchers.IO) {
                             try {
-                                val state = blueFalcon.connectionState(device.peripheral)
-                                if (state == BluetoothPeripheralState.Connected) {
+                                // peripheralState() (ADR 0008) reflects the same authoritative
+                                // state as connectionStates, so this check is consistent with the
+                                // connected/connecting flags already driving the UI.
+                                val state = blueFalcon.peripheralState(device.peripheral)
+                                if (state is PeripheralConnectionState.Connected || state is PeripheralConnectionState.Ready) {
                                     blueFalcon.discoverServices(device.peripheral)
                                 }
                             } catch (e: Exception) {
@@ -526,7 +534,8 @@ class BluetoothDeviceViewModel(
                 notificationData = existingDevice?.notificationData ?: emptyMap(),
                 fotaState = existingDevice?.fotaState ?: FotaState.Idle,
                 rssi = peripheral.rssi ?: existingDevice?.rssi,
-                manufacturerData = mfData.ifEmpty { existingDevice?.manufacturerData ?: emptyMap() }
+                manufacturerData = mfData.ifEmpty { existingDevice?.manufacturerData ?: emptyMap() },
+                connectionError = existingDevice?.connectionError
             )
         }
         return updatedDevices
@@ -548,4 +557,32 @@ class BluetoothDeviceViewModel(
         }
         return null
     }
+}
+
+/**
+ * Folds a [PeripheralConnectionState] (ADR 0008) into this device's UI-facing
+ * connected/connecting/connectionError fields.
+ */
+private fun EnhancedBluetoothPeripheral.applyConnectionState(
+    state: PeripheralConnectionState
+): EnhancedBluetoothPeripheral = when (state) {
+    is PeripheralConnectionState.Connecting ->
+        copy(connecting = true, connected = false, connectionError = null)
+    is PeripheralConnectionState.Connected, is PeripheralConnectionState.Ready ->
+        copy(connecting = false, connected = true, connectionError = null)
+    is PeripheralConnectionState.Disconnecting ->
+        copy(connecting = true)
+    is PeripheralConnectionState.Disconnected ->
+        copy(
+            connecting = false,
+            connected = false,
+            connectionError = state.reason?.toDisplayMessage()
+        )
+}
+
+/** Human-readable message for a [DisconnectReason], or `null` for an expected user-initiated disconnect. */
+private fun DisconnectReason.toDisplayMessage(): String? = when (this) {
+    is DisconnectReason.UserInitiated -> null
+    is DisconnectReason.ConnectFailed -> "Failed to connect: ${cause.message ?: cause::class.simpleName}"
+    is DisconnectReason.Unexpected -> "Connection lost unexpectedly"
 }

--- a/examples/ComposeMultiplatform-3.0-Example/shared/src/commonMain/kotlin/com/example/bluefalconcomposemultiplatform/ble/presentation/EnhancedBluetoothPeripheral.kt
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/src/commonMain/kotlin/com/example/bluefalconcomposemultiplatform/ble/presentation/EnhancedBluetoothPeripheral.kt
@@ -18,5 +18,12 @@ data class EnhancedBluetoothPeripheral(
     /** Cached RSSI, kept fresh by rssiUpdates flow (falls back to peripheral.rssi on first discovery). */
     val rssi: Float? = null,
     /** Manufacturer-specific data from scan advertisement: company ID → hex payload string. */
-    val manufacturerData: Map<Int, String> = emptyMap()
+    val manufacturerData: Map<Int, String> = emptyMap(),
+    /**
+     * Human-readable reason the last connect attempt failed or the peripheral unexpectedly
+     * disconnected, derived from [dev.bluefalcon.core.DisconnectReason] via
+     * [dev.bluefalcon.core.BlueFalcon.connectionStates]. `null` while connected/connecting or if
+     * the peripheral has never failed/dropped.
+     */
+    val connectionError: String? = null
 )

--- a/examples/ComposeMultiplatform-3.0-Example/shared/src/commonMain/kotlin/com/example/bluefalconcomposemultiplatform/ble/presentation/component/DeviceScanView.kt
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/src/commonMain/kotlin/com/example/bluefalconcomposemultiplatform/ble/presentation/component/DeviceScanView.kt
@@ -232,6 +232,7 @@ fun DeviceScanView(
                             manufacturerData = device.manufacturerData,
                             connected = device.connected,
                             connecting = device.connecting,
+                            connectionError = device.connectionError,
                             onConnect = { onEvent(UiEvent.OnConnectClick(device.peripheral.uuid)) },
                             onSelect = { onEvent(UiEvent.OnDeviceSelected(device.peripheral.uuid)) }
                         )

--- a/examples/ComposeMultiplatform-3.0-Example/shared/src/commonMain/kotlin/com/example/bluefalconcomposemultiplatform/ble/presentation/component/FoundDeviceCard.kt
+++ b/examples/ComposeMultiplatform-3.0-Example/shared/src/commonMain/kotlin/com/example/bluefalconcomposemultiplatform/ble/presentation/component/FoundDeviceCard.kt
@@ -54,6 +54,8 @@ fun ScanResultCard(
     manufacturerData: Map<Int, String> = emptyMap(),
     connected: Boolean,
     connecting: Boolean = false,
+    /** Message from the last failed connect attempt or unexpected disconnect (ADR 0008); null when none. */
+    connectionError: String? = null,
     onConnect: () -> Unit,
     onSelect: () -> Unit
 ) {
@@ -122,6 +124,14 @@ fun ScanResultCard(
                         text = "MFR: $mfText",
                         fontSize = 10.sp,
                         color = MaterialTheme.colorScheme.outline
+                    )
+                }
+                if (!connectionError.isNullOrBlank() && !connected && !connecting) {
+                    Text(
+                        text = connectionError,
+                        fontSize = 10.sp,
+                        color = MaterialTheme.colorScheme.error,
+                        fontWeight = FontWeight.Medium
                     )
                 }
             }

--- a/library/core/src/commonMain/kotlin/dev/bluefalcon/core/BlueFalcon.kt
+++ b/library/core/src/commonMain/kotlin/dev/bluefalcon/core/BlueFalcon.kt
@@ -3,8 +3,14 @@ package dev.bluefalcon.core
 import dev.bluefalcon.core.plugin.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 
 /**
  * Main Blue Falcon client that wraps an engine and provides plugin support
@@ -18,6 +24,12 @@ class BlueFalcon(
      */
     val plugins: PluginRegistry = PluginRegistry()
 
+    /**
+     * Backing store for the structured per-peripheral connection state machine (ADR 0008),
+     * keyed by [BluetoothPeripheral.uuid].
+     */
+    private val _connectionStates = MutableStateFlow<Map<String, PeripheralConnectionState>>(emptyMap())
+
     init {
         engine.scope.launch {
             engine.characteristicNotifications.collect { notification ->
@@ -28,6 +40,53 @@ class BlueFalcon(
                         value = notification.value
                     )
                 )
+            }
+        }
+
+        engine.scope.launch {
+            engine.connectionStateUpdates.collect { update ->
+                val uuid = update.peripheral.uuid
+                when (update.state) {
+                    BluetoothPeripheralState.Connected -> {
+                        _connectionStates.update { it + (uuid to PeripheralConnectionState.Connected) }
+                    }
+                    BluetoothPeripheralState.Disconnected -> {
+                        val previous = _connectionStates.value[uuid]
+                        val reason = when (previous) {
+                            is PeripheralConnectionState.Disconnecting -> DisconnectReason.UserInitiated
+                            is PeripheralConnectionState.Connecting -> DisconnectReason.ConnectFailed(
+                                BluetoothUnknownException()
+                            )
+                            is PeripheralConnectionState.Connected,
+                            is PeripheralConnectionState.Ready -> DisconnectReason.Unexpected
+                            else -> null
+                        }
+                        _connectionStates.update {
+                            it + (uuid to PeripheralConnectionState.Disconnected(reason))
+                        }
+                    }
+                    BluetoothPeripheralState.Connecting -> {
+                        _connectionStates.update { it + (uuid to PeripheralConnectionState.Connecting) }
+                    }
+                    BluetoothPeripheralState.Disconnecting -> {
+                        _connectionStates.update { it + (uuid to PeripheralConnectionState.Disconnecting) }
+                    }
+                    BluetoothPeripheralState.Unknown -> Unit
+                }
+            }
+        }
+
+        engine.scope.launch {
+            engine.serviceDiscoveryUpdates.collect { update ->
+                if (update.phase != ServiceDiscoveryPhase.ServicesDiscovered) return@collect
+                val uuid = update.peripheral.uuid
+                _connectionStates.update { current ->
+                    if (current[uuid] == PeripheralConnectionState.Connected) {
+                        current + (uuid to PeripheralConnectionState.Ready)
+                    } else {
+                        current
+                    }
+                }
             }
         }
     }
@@ -94,6 +153,48 @@ class BlueFalcon(
      * ```
      */
     val serviceDiscoveryUpdates: SharedFlow<ServiceDiscoveryUpdate> get() = engine.serviceDiscoveryUpdates
+
+    /**
+     * Structured, per-peripheral connection state (ADR 0008), keyed by [BluetoothPeripheral.uuid].
+     *
+     * Derived from [connectionStateUpdates] and [serviceDiscoveryUpdates]. Prefer
+     * [connectionStateFlow] or [peripheralState] for working with a single peripheral.
+     */
+    val connectionStates: StateFlow<Map<String, PeripheralConnectionState>> = _connectionStates.asStateFlow()
+
+    /**
+     * The current, structured connection state of [peripheral] (ADR 0008).
+     *
+     * Unlike [connectionState], this folds in GATT service discovery and typed disconnect
+     * reasons. Returns [PeripheralConnectionState.Disconnected] with a `null` reason for a
+     * peripheral that has never been connected to.
+     */
+    fun peripheralState(peripheral: BluetoothPeripheral): PeripheralConnectionState =
+        _connectionStates.value[peripheral.uuid] ?: PeripheralConnectionState.Disconnected()
+
+    /**
+     * A [StateFlow] of [peripheral]'s structured connection state (ADR 0008).
+     *
+     * Unlike [connectionStateUpdates] (a `SharedFlow` with no replay), a collector that
+     * subscribes after [peripheral] already connected immediately observes the current state
+     * instead of waiting for the next transition.
+     *
+     * ```kotlin
+     * launch {
+     *     blueFalcon.connectionStateFlow(peripheral).collect { state ->
+     *         when (state) {
+     *             is PeripheralConnectionState.Ready -> println("Ready to use ${peripheral.name}")
+     *             is PeripheralConnectionState.Disconnected -> println("Disconnected: ${state.reason}")
+     *             else -> Unit
+     *         }
+     *     }
+     * }
+     * ```
+     */
+    fun connectionStateFlow(peripheral: BluetoothPeripheral): StateFlow<PeripheralConnectionState> =
+        _connectionStates
+            .map { it[peripheral.uuid] ?: PeripheralConnectionState.Disconnected() }
+            .stateIn(engine.scope, SharingStarted.Eagerly, peripheralState(peripheral))
     
     /**
      * Scan for BLE devices
@@ -122,9 +223,17 @@ class BlueFalcon(
      * Connect to a peripheral
      */
     suspend fun connect(peripheral: BluetoothPeripheral, autoConnect: Boolean = false) {
-        plugins.interceptConnect(ConnectCall(peripheral, autoConnect)) { call ->
+        _connectionStates.update {
+            it + (peripheral.uuid to PeripheralConnectionState.Connecting)
+        }
+        val result = plugins.interceptConnect(ConnectCall(peripheral, autoConnect)) { call ->
             runCatching {
                 engine.connect(call.peripheral, call.autoConnect)
+            }
+        }
+        result.exceptionOrNull()?.let { cause ->
+            _connectionStates.update {
+                it + (peripheral.uuid to PeripheralConnectionState.Disconnected(DisconnectReason.ConnectFailed(cause)))
             }
         }
     }
@@ -133,6 +242,9 @@ class BlueFalcon(
      * Disconnect from a peripheral
      */
     suspend fun disconnect(peripheral: BluetoothPeripheral) {
+        _connectionStates.update {
+            it + (peripheral.uuid to PeripheralConnectionState.Disconnecting)
+        }
         plugins.interceptDisconnect(DisconnectCall(peripheral)) { call ->
             runCatching {
                 engine.disconnect(call.peripheral)

--- a/library/core/src/commonMain/kotlin/dev/bluefalcon/core/PeripheralConnectionState.kt
+++ b/library/core/src/commonMain/kotlin/dev/bluefalcon/core/PeripheralConnectionState.kt
@@ -1,0 +1,57 @@
+package dev.bluefalcon.core
+
+/**
+ * Typed, per-peripheral connection state derived by [BlueFalcon] from the lower-level
+ * [BlueFalconEngine.connectionStateUpdates] and [BlueFalconEngine.serviceDiscoveryUpdates]
+ * flows, plus the outcome of [BlueFalcon.connect]/[BlueFalcon.disconnect] calls.
+ *
+ * Unlike polling [BlueFalcon.connectionState] or collecting the raw `SharedFlow`s directly,
+ * [BlueFalcon.connectionStateFlow] exposes this as a [kotlinx.coroutines.flow.StateFlow], so a
+ * collector that subscribes after a peripheral already connected immediately observes the
+ * current state instead of waiting for the next transition.
+ *
+ * [Ready] reflects only that the GATT *service* table has been populated (i.e.
+ * [ServiceDiscoveryPhase.ServicesDiscovered] was observed) — it does not imply that
+ * characteristics for every service have been discovered. Consumers still choose which services
+ * they care about and call [BlueFalcon.discoverCharacteristics] themselves, exactly as they do
+ * today via [BlueFalcon.serviceDiscoveryUpdates].
+ *
+ * See ADR 0008 for the full rationale and derivation rules.
+ */
+sealed class PeripheralConnectionState {
+    /**
+     * Not connected. [reason] is `null` only for a peripheral that has never been connected to.
+     */
+    data class Disconnected(val reason: DisconnectReason? = null) : PeripheralConnectionState()
+
+    /** [BlueFalcon.connect] was called and a platform response is pending. */
+    object Connecting : PeripheralConnectionState()
+
+    /** The link is up, but the GATT service table has not been populated yet. */
+    object Connected : PeripheralConnectionState()
+
+    /** The link is up and the GATT service table has been populated. */
+    object Ready : PeripheralConnectionState()
+
+    /** [BlueFalcon.disconnect] was called and a platform response is pending. */
+    object Disconnecting : PeripheralConnectionState()
+}
+
+/**
+ * Why a peripheral transitioned to [PeripheralConnectionState.Disconnected].
+ */
+sealed class DisconnectReason {
+    /** [BlueFalcon.disconnect] was called by the application. */
+    object UserInitiated : DisconnectReason()
+
+    /** [BlueFalcon.connect] itself failed (e.g. the platform rejected the request). */
+    data class ConnectFailed(val cause: Throwable) : DisconnectReason()
+
+    /**
+     * The peripheral disconnected while [PeripheralConnectionState.Connected] or
+     * [PeripheralConnectionState.Ready], without the application having called
+     * [BlueFalcon.disconnect]. The underlying platform cause is not currently surfaced by
+     * [BlueFalconEngine] (see ADR 0008's Negative consequences).
+     */
+    object Unexpected : DisconnectReason()
+}

--- a/library/core/src/commonMain/kotlin/dev/bluefalcon/core/plugin/BlueFalconPlugin.kt
+++ b/library/core/src/commonMain/kotlin/dev/bluefalcon/core/plugin/BlueFalconPlugin.kt
@@ -1,6 +1,7 @@
 package dev.bluefalcon.core.plugin
 
 import dev.bluefalcon.core.*
+import kotlin.time.Duration
 
 /**
  * Base interface for Blue Falcon plugins
@@ -76,6 +77,33 @@ interface BlueFalconPlugin {
         characteristic: BluetoothCharacteristic,
         value: ByteArray
     ) {}
+}
+
+/**
+ * The kind of operation a [RetryCapable] plugin is being asked to retry.
+ */
+enum class RetryableOperation {
+    CONNECT,
+    READ,
+    WRITE
+}
+
+/**
+ * Optional capability that a [BlueFalconPlugin] can implement to actually drive retries of
+ * failed operations. The [PluginRegistry] consults every installed [RetryCapable] plugin after
+ * an operation fails and, if any of them return a non-null delay, re-invokes the underlying
+ * platform operation after waiting for that delay.
+ */
+interface RetryCapable {
+    /**
+     * Called after [operation] fails with [error].
+     *
+     * @param attempt zero-based index of the retry being considered (0 for the first retry
+     * following the initial failed attempt).
+     * @return the [Duration] to wait before retrying, or `null` if this operation should not be
+     * retried (either because the error isn't retryable or the retry budget is exhausted).
+     */
+    suspend fun retryDelay(operation: RetryableOperation, attempt: Int, error: Throwable): Duration?
 }
 
 /**

--- a/library/core/src/commonMain/kotlin/dev/bluefalcon/core/plugin/PluginRegistry.kt
+++ b/library/core/src/commonMain/kotlin/dev/bluefalcon/core/plugin/PluginRegistry.kt
@@ -2,6 +2,7 @@ package dev.bluefalcon.core.plugin
 
 import dev.bluefalcon.core.CharacteristicWriteResult
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 
 /**
  * Registry for managing installed plugins
@@ -45,6 +46,43 @@ class PluginRegistry {
     }
     
     /**
+     * Plugins that can decide whether a failed operation should be retried.
+     */
+    private val retryCapablePlugins: List<RetryCapable>
+        get() = plugins.filterIsInstance<RetryCapable>()
+
+    /**
+     * Re-invokes [proceed] while any installed [RetryCapable] plugin requests a retry after
+     * [result] represents a failure. Returns the last result observed.
+     */
+    private suspend fun <C, R> retryUntilSatisfied(
+        operation: RetryableOperation,
+        call: C,
+        initialResult: R,
+        isFailure: (R) -> Boolean,
+        failureCause: (R) -> Throwable?,
+        proceed: suspend (C) -> R
+    ): R {
+        val retryPlugins = retryCapablePlugins
+        if (retryPlugins.isEmpty()) {
+            return initialResult
+        }
+
+        var result = initialResult
+        var attempt = 0
+        while (isFailure(result)) {
+            val error = failureCause(result) ?: break
+            val delayDuration = retryPlugins.firstNotNullOfOrNull {
+                it.retryDelay(operation, attempt, error)
+            } ?: break
+            delay(delayDuration)
+            attempt++
+            result = proceed(call)
+        }
+        return result
+    }
+
+    /**
      * Execute connect interceptors
      */
     suspend fun interceptConnect(call: ConnectCall, proceed: suspend (ConnectCall) -> Result<Unit>): Result<Unit> {
@@ -52,7 +90,15 @@ class PluginRegistry {
         for (plugin in plugins) {
             currentCall = plugin.onBeforeConnect(currentCall)
         }
-        val result = proceed(currentCall)
+        val initialResult = proceed(currentCall)
+        val result = retryUntilSatisfied(
+            operation = RetryableOperation.CONNECT,
+            call = currentCall,
+            initialResult = initialResult,
+            isFailure = { it.isFailure },
+            failureCause = { it.exceptionOrNull() },
+            proceed = proceed
+        )
         for (plugin in plugins.reversed()) {
             plugin.onAfterConnect(currentCall, result)
         }
@@ -67,7 +113,15 @@ class PluginRegistry {
         for (plugin in plugins) {
             currentCall = plugin.onBeforeRead(currentCall)
         }
-        val result = proceed(currentCall)
+        val initialResult = proceed(currentCall)
+        val result = retryUntilSatisfied(
+            operation = RetryableOperation.READ,
+            call = currentCall,
+            initialResult = initialResult,
+            isFailure = { it.isFailure },
+            failureCause = { it.exceptionOrNull() },
+            proceed = proceed
+        )
         for (plugin in plugins.reversed()) {
             plugin.onAfterRead(currentCall, result)
         }
@@ -82,7 +136,15 @@ class PluginRegistry {
         for (plugin in plugins) {
             currentCall = plugin.onBeforeWrite(currentCall)
         }
-        val result = proceed(currentCall)
+        val initialResult = proceed(currentCall)
+        val result = retryUntilSatisfied(
+            operation = RetryableOperation.WRITE,
+            call = currentCall,
+            initialResult = initialResult,
+            isFailure = { it.isFailure },
+            failureCause = { it.exceptionOrNull() },
+            proceed = proceed
+        )
         for (plugin in plugins.reversed()) {
             plugin.onAfterWrite(currentCall, result)
         }

--- a/library/core/src/commonTest/kotlin/dev/bluefalcon/core/PeripheralConnectionStateTest.kt
+++ b/library/core/src/commonTest/kotlin/dev/bluefalcon/core/PeripheralConnectionStateTest.kt
@@ -1,0 +1,189 @@
+package dev.bluefalcon.core
+
+import dev.bluefalcon.core.mocks.FakeBlueFalconEngine
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for the structured per-peripheral connection state machine (ADR 0008).
+ */
+class PeripheralConnectionStateTest {
+
+    @Test
+    fun `never-connected peripheral reports Disconnected with no reason`() = runTest {
+        val engine = FakeBlueFalconEngine()
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        val state = blueFalcon.peripheralState(peripheral)
+
+        assertEquals(PeripheralConnectionState.Disconnected(null), state)
+    }
+
+    @Test
+    fun `connect sets Connecting immediately`() = runTest {
+        val engine = FakeBlueFalconEngine().apply {
+            onConnect = {} // don't emit Connected synchronously; simulate async platform callback
+        }
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        blueFalcon.connect(peripheral)
+
+        assertEquals(PeripheralConnectionState.Connecting, blueFalcon.peripheralState(peripheral))
+    }
+
+    @Test
+    fun `synchronous connect failure transitions directly to Disconnected with ConnectFailed`() = runTest {
+        val engine = FakeBlueFalconEngine().apply {
+            shouldFailConnect = true
+        }
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        blueFalcon.connect(peripheral)
+
+        val state = blueFalcon.peripheralState(peripheral)
+        val disconnected = assertIs<PeripheralConnectionState.Disconnected>(state)
+        assertIs<DisconnectReason.ConnectFailed>(disconnected.reason)
+    }
+
+    @Test
+    fun `Connected event transitions Connecting to Connected`() = runTest {
+        val engine = FakeBlueFalconEngine()
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        blueFalcon.connect(peripheral)
+        engine.emitConnectionStateUpdate(ConnectionStateUpdate(peripheral, BluetoothPeripheralState.Connected))
+
+        assertEquals(PeripheralConnectionState.Connected, blueFalcon.peripheralState(peripheral))
+    }
+
+    @Test
+    fun `ServicesDiscovered after Connected transitions to Ready`() = runTest {
+        val engine = FakeBlueFalconEngine()
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        blueFalcon.connect(peripheral)
+        engine.emitConnectionStateUpdate(ConnectionStateUpdate(peripheral, BluetoothPeripheralState.Connected))
+        engine.emitServiceDiscoveryUpdate(
+            ServiceDiscoveryUpdate(peripheral, ServiceDiscoveryPhase.ServicesDiscovered)
+        )
+
+        assertEquals(PeripheralConnectionState.Ready, blueFalcon.peripheralState(peripheral))
+    }
+
+    @Test
+    fun `ServicesDiscovered is ignored when not currently Connected`() = runTest {
+        val engine = FakeBlueFalconEngine()
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        // No connect() call at all - peripheral is Disconnected.
+        engine.emitServiceDiscoveryUpdate(
+            ServiceDiscoveryUpdate(peripheral, ServiceDiscoveryPhase.ServicesDiscovered)
+        )
+
+        assertEquals(PeripheralConnectionState.Disconnected(null), blueFalcon.peripheralState(peripheral))
+    }
+
+    @Test
+    fun `CharacteristicsDiscovered does not change state`() = runTest {
+        val engine = FakeBlueFalconEngine()
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        blueFalcon.connect(peripheral)
+        engine.emitConnectionStateUpdate(ConnectionStateUpdate(peripheral, BluetoothPeripheralState.Connected))
+        engine.emitServiceDiscoveryUpdate(
+            ServiceDiscoveryUpdate(peripheral, ServiceDiscoveryPhase.CharacteristicsDiscovered)
+        )
+
+        // Still Connected, not Ready, since only characteristics (not services) were reported.
+        assertEquals(PeripheralConnectionState.Connected, blueFalcon.peripheralState(peripheral))
+    }
+
+    @Test
+    fun `disconnect sets Disconnecting then UserInitiated on completion`() = runTest {
+        val engine = FakeBlueFalconEngine()
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        blueFalcon.connect(peripheral)
+        engine.emitConnectionStateUpdate(ConnectionStateUpdate(peripheral, BluetoothPeripheralState.Connected))
+        blueFalcon.disconnect(peripheral)
+        assertEquals(PeripheralConnectionState.Disconnecting, blueFalcon.peripheralState(peripheral))
+
+        engine.emitConnectionStateUpdate(ConnectionStateUpdate(peripheral, BluetoothPeripheralState.Disconnected))
+
+        val state = blueFalcon.peripheralState(peripheral)
+        val disconnected = assertIs<PeripheralConnectionState.Disconnected>(state)
+        assertSame(DisconnectReason.UserInitiated, disconnected.reason)
+    }
+
+    @Test
+    fun `unexpected drop while Connected reports Unexpected reason`() = runTest {
+        val engine = FakeBlueFalconEngine()
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        blueFalcon.connect(peripheral)
+        engine.emitConnectionStateUpdate(ConnectionStateUpdate(peripheral, BluetoothPeripheralState.Connected))
+        // No disconnect() call - the peripheral just drops.
+        engine.emitConnectionStateUpdate(ConnectionStateUpdate(peripheral, BluetoothPeripheralState.Disconnected))
+
+        val state = blueFalcon.peripheralState(peripheral)
+        val disconnected = assertIs<PeripheralConnectionState.Disconnected>(state)
+        assertSame(DisconnectReason.Unexpected, disconnected.reason)
+    }
+
+    @Test
+    fun `unexpected drop while Ready reports Unexpected reason`() = runTest {
+        val engine = FakeBlueFalconEngine()
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        blueFalcon.connect(peripheral)
+        engine.emitConnectionStateUpdate(ConnectionStateUpdate(peripheral, BluetoothPeripheralState.Connected))
+        engine.emitServiceDiscoveryUpdate(
+            ServiceDiscoveryUpdate(peripheral, ServiceDiscoveryPhase.ServicesDiscovered)
+        )
+        engine.emitConnectionStateUpdate(ConnectionStateUpdate(peripheral, BluetoothPeripheralState.Disconnected))
+
+        val state = blueFalcon.peripheralState(peripheral)
+        val disconnected = assertIs<PeripheralConnectionState.Disconnected>(state)
+        assertSame(DisconnectReason.Unexpected, disconnected.reason)
+    }
+
+    @Test
+    fun `connectionStateFlow reflects current value immediately without a prior event`() = runTest {
+        val engine = FakeBlueFalconEngine()
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        blueFalcon.connect(peripheral)
+
+        // Subscribing "late" (after connect() already ran) still observes Connecting immediately,
+        // since connectionStateFlow is backed by a StateFlow rather than a SharedFlow.
+        assertEquals(PeripheralConnectionState.Connecting, blueFalcon.connectionStateFlow(peripheral).value)
+    }
+
+    @Test
+    fun `connectionStates map only contains peripherals that have been touched`() = runTest {
+        val engine = FakeBlueFalconEngine()
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+
+        assertNull(blueFalcon.connectionStates.value[peripheral.uuid])
+
+        blueFalcon.connect(peripheral)
+
+        assertEquals(PeripheralConnectionState.Connecting, blueFalcon.connectionStates.value[peripheral.uuid])
+    }
+}

--- a/library/core/src/commonTest/kotlin/dev/bluefalcon/core/mocks/FakeBlueFalconEngine.kt
+++ b/library/core/src/commonTest/kotlin/dev/bluefalcon/core/mocks/FakeBlueFalconEngine.kt
@@ -45,6 +45,16 @@ class FakeBlueFalconEngine : BlueFalconEngine {
     var shouldFailConnect = false
     var shouldFailRead = false
     var shouldFailWrite = false
+
+    // Number of remaining calls that should fail before the operation succeeds. Decremented on
+    // each invocation while > 0, allowing tests to simulate transient failures that eventually
+    // resolve (e.g. to exercise retry plugins).
+    var failConnectTimes = 0
+    var failReadTimes = 0
+    var failWriteTimes = 0
+    var connectCallCount = 0
+    var readCallCount = 0
+    var writeCallCount = 0
     var typedWriteResult: CharacteristicWriteResult = CharacteristicWriteResult.Unsupported
     var typedWriteFailure: Throwable? = null
     var lastTypedWriteValue: ByteArray? = null
@@ -72,7 +82,9 @@ class FakeBlueFalconEngine : BlueFalconEngine {
     
     override suspend fun connect(peripheral: BluetoothPeripheral, autoConnect: Boolean) {
         connectCalled = true
-        if (shouldFailConnect) {
+        connectCallCount++
+        if (shouldFailConnect || failConnectTimes > 0) {
+            if (failConnectTimes > 0) failConnectTimes--
             throw BluetoothUnknownException()
         }
         onConnect()
@@ -110,7 +122,9 @@ class FakeBlueFalconEngine : BlueFalconEngine {
         peripheral: BluetoothPeripheral,
         characteristic: BluetoothCharacteristic
     ) {
-        if (shouldFailRead) {
+        readCallCount++
+        if (shouldFailRead || failReadTimes > 0) {
+            if (failReadTimes > 0) failReadTimes--
             throw BluetoothUnknownException()
         }
     }
@@ -121,7 +135,9 @@ class FakeBlueFalconEngine : BlueFalconEngine {
         value: ByteArray,
         writeType: Int?
     ) {
-        if (shouldFailWrite) {
+        writeCallCount++
+        if (shouldFailWrite || failWriteTimes > 0) {
+            if (failWriteTimes > 0) failWriteTimes--
             throw BluetoothUnknownException()
         }
     }
@@ -241,6 +257,12 @@ class FakeBlueFalconEngine : BlueFalconEngine {
         shouldFailConnect = false
         shouldFailRead = false
         shouldFailWrite = false
+        failConnectTimes = 0
+        failReadTimes = 0
+        failWriteTimes = 0
+        connectCallCount = 0
+        readCallCount = 0
+        writeCallCount = 0
         typedWriteResult = CharacteristicWriteResult.Unsupported
         typedWriteFailure = null
         lastTypedWriteValue = null

--- a/library/core/src/commonTest/kotlin/dev/bluefalcon/core/plugin/PluginTest.kt
+++ b/library/core/src/commonTest/kotlin/dev/bluefalcon/core/plugin/PluginTest.kt
@@ -231,6 +231,110 @@ class PluginTest {
         )
     }
     
+    @Test
+    fun `retry capable plugin causes connect to be re-invoked on failure`() = runTest {
+        // Given
+        val engine = FakeBlueFalconEngine().apply {
+            failConnectTimes = 2 // fails twice, succeeds on the 3rd attempt
+        }
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+        blueFalcon.plugins.install(alwaysRetryPlugin(maxAttempts = 3))
+
+        // When
+        blueFalcon.connect(peripheral)
+
+        // Then
+        assertEquals(3, engine.connectCallCount)
+    }
+
+    @Test
+    fun `retry capable plugin gives up once its retry budget is exhausted`() = runTest {
+        // Given
+        val engine = FakeBlueFalconEngine().apply {
+            failConnectTimes = Int.MAX_VALUE // always fails
+        }
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+        blueFalcon.plugins.install(alwaysRetryPlugin(maxAttempts = 3))
+
+        // When
+        blueFalcon.connect(peripheral)
+
+        // Then - initial attempt + 2 retries = 3 total attempts, then it gives up
+        assertEquals(3, engine.connectCallCount)
+    }
+
+    @Test
+    fun `retry capable plugin causes read to be re-invoked until it succeeds`() = runTest {
+        // Given
+        val engine = FakeBlueFalconEngine().apply {
+            failReadTimes = 1
+        }
+        val peripheral = engine.createFakePeripheral("Device")
+        val characteristic = FakeCharacteristic(uuid = "00002a37-0000-1000-8000-00805f9b34fb".toUuid())
+        val blueFalcon = BlueFalcon(engine)
+        blueFalcon.plugins.install(alwaysRetryPlugin(maxAttempts = 3))
+
+        // When
+        blueFalcon.readCharacteristic(peripheral, characteristic)
+
+        // Then
+        assertEquals(2, engine.readCallCount)
+    }
+
+    @Test
+    fun `retry capable plugin causes write to be re-invoked until it succeeds`() = runTest {
+        // Given
+        val engine = FakeBlueFalconEngine().apply {
+            failWriteTimes = 1
+        }
+        val peripheral = engine.createFakePeripheral("Device")
+        val characteristic = FakeCharacteristic(uuid = "00002a37-0000-1000-8000-00805f9b34fb".toUuid())
+        val blueFalcon = BlueFalcon(engine)
+        blueFalcon.plugins.install(alwaysRetryPlugin(maxAttempts = 3))
+
+        // When
+        blueFalcon.writeCharacteristic(peripheral, characteristic, byteArrayOf(1), null)
+
+        // Then
+        assertEquals(2, engine.writeCallCount)
+    }
+
+    @Test
+    fun `without a retry capable plugin failures are not retried`() = runTest {
+        // Given
+        val engine = FakeBlueFalconEngine().apply {
+            failConnectTimes = 1
+        }
+        val peripheral = engine.createFakePeripheral("Device")
+        val blueFalcon = BlueFalcon(engine)
+        // No plugins installed at all
+
+        // When
+        blueFalcon.connect(peripheral)
+
+        // Then - only the single, failed attempt was made
+        assertEquals(1, engine.connectCallCount)
+    }
+
+    /**
+     * A minimal [RetryCapable] plugin used purely to exercise [PluginRegistry]'s retry loop
+     * without depending on the real `blue-falcon-plugin-retry` module from core tests.
+     */
+    private fun alwaysRetryPlugin(maxAttempts: Int) = object : BlueFalconPlugin, RetryCapable {
+        override fun install(client: BlueFalconClient, config: PluginConfig) {}
+
+        override suspend fun retryDelay(
+            operation: RetryableOperation,
+            attempt: Int,
+            error: Throwable
+        ): kotlin.time.Duration? {
+            if (attempt >= maxAttempts - 1) return null
+            return kotlin.time.Duration.ZERO
+        }
+    }
+
     private fun createTestPlugin(name: String, order: MutableList<String>) = 
         object : BlueFalconPlugin {
             override fun install(client: BlueFalconClient, config: PluginConfig) {}

--- a/library/plugins/retry/build.gradle.kts
+++ b/library/plugins/retry/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinx_coroutines_version")
             }
         }
     }

--- a/library/plugins/retry/src/commonMain/kotlin/dev/bluefalcon/plugins/retry/RetryPlugin.kt
+++ b/library/plugins/retry/src/commonMain/kotlin/dev/bluefalcon/plugins/retry/RetryPlugin.kt
@@ -2,159 +2,103 @@ package dev.bluefalcon.plugins.retry
 
 import dev.bluefalcon.core.*
 import dev.bluefalcon.core.plugin.*
-import kotlinx.coroutines.delay
+import kotlin.math.pow
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Plugin that automatically retries failed BLE operations.
- * 
+ * Plugin that automatically retries failed BLE operations with exponential backoff.
+ *
+ * The plugin implements [RetryCapable], which the [PluginRegistry] consults after a connect,
+ * read, or write operation fails. When installed, failed operations are genuinely re-invoked
+ * against the underlying platform engine (not just re-reported) until they succeed, the retry
+ * budget is exhausted, or [retryOn] rejects the error.
+ *
  * Usage:
  * ```
- * install(RetryPlugin) {
+ * install(RetryPlugin.create {
  *     maxRetries = 3
  *     initialDelay = 500.milliseconds
  *     maxDelay = 5.seconds
  *     backoffMultiplier = 2.0
  *     retryOn = { error -> error is BluetoothException }
- * }
+ * })
  * ```
  */
-class RetryPlugin(private val config: Config) : BlueFalconPlugin {
-    
+class RetryPlugin(private val config: Config) : BlueFalconPlugin, RetryCapable {
+
     /**
      * Configuration for the retry plugin
      */
     class Config : PluginConfig() {
         /**
-         * Maximum number of retry attempts
+         * Maximum number of attempts made for an operation (the initial attempt plus retries).
+         * A value of 3 means the initial attempt followed by up to 2 retries.
          */
         var maxRetries: Int = 3
-        
+
         /**
          * Initial delay before first retry
          */
         var initialDelay: Duration = 500.milliseconds
-        
+
         /**
          * Maximum delay between retries
          */
         var maxDelay: Duration = 5.seconds
-        
+
         /**
          * Multiplier for exponential backoff
          */
         var backoffMultiplier: Double = 2.0
-        
+
         /**
          * Predicate to determine if an error should trigger a retry
          */
         var retryOn: (Throwable) -> Boolean = { true }
-        
+
         /**
          * Whether to retry connect operations
          */
         var retryConnect: Boolean = true
-        
+
         /**
          * Whether to retry read operations
          */
         var retryRead: Boolean = true
-        
+
         /**
          * Whether to retry write operations
          */
         var retryWrite: Boolean = true
     }
-    
+
     override fun install(client: BlueFalconClient, config: PluginConfig) {
-        // Plugin installed
+        // Plugin installed; retry behaviour is driven entirely through RetryCapable.retryDelay,
+        // which PluginRegistry invokes directly.
     }
-    
-    override suspend fun onBeforeConnect(call: ConnectCall): ConnectCall {
-        return call
-    }
-    
-    override suspend fun onAfterConnect(call: ConnectCall, result: Result<Unit>) {
-        if (config.retryConnect && result.isFailure) {
-            val error = result.exceptionOrNull()
-            if (error != null && config.retryOn(error)) {
-                retryOperation("connect", config.maxRetries) {
-                    // In a real implementation, this would trigger the actual connect operation
-                    // For now, this is a placeholder showing the retry logic structure
-                    result.getOrThrow()
-                }
-            }
+
+    override suspend fun retryDelay(
+        operation: RetryableOperation,
+        attempt: Int,
+        error: Throwable
+    ): Duration? {
+        val enabled = when (operation) {
+            RetryableOperation.CONNECT -> config.retryConnect
+            RetryableOperation.READ -> config.retryRead
+            RetryableOperation.WRITE -> config.retryWrite
         }
+        if (!enabled) return null
+        if (attempt >= config.maxRetries - 1) return null
+        if (!config.retryOn(error)) return null
+
+        val scaledDelayMs = config.initialDelay.inWholeMilliseconds *
+            config.backoffMultiplier.pow(attempt)
+        val delayMs = scaledDelayMs.toLong().coerceAtMost(config.maxDelay.inWholeMilliseconds)
+        return delayMs.milliseconds
     }
-    
-    override suspend fun onBeforeRead(call: ReadCall): ReadCall {
-        return call
-    }
-    
-    override suspend fun onAfterRead(call: ReadCall, result: Result<ByteArray?>) {
-        if (config.retryRead && result.isFailure) {
-            val error = result.exceptionOrNull()
-            if (error != null && config.retryOn(error)) {
-                retryOperation("read", config.maxRetries) {
-                    // Placeholder for actual read retry
-                    result.getOrThrow()
-                }
-            }
-        }
-    }
-    
-    override suspend fun onBeforeWrite(call: WriteCall): WriteCall {
-        return call
-    }
-    
-    override suspend fun onAfterWrite(call: WriteCall, result: Result<Unit>) {
-        if (config.retryWrite && result.isFailure) {
-            val error = result.exceptionOrNull()
-            if (error != null && config.retryOn(error)) {
-                retryOperation("write", config.maxRetries) {
-                    // Placeholder for actual write retry
-                    result.getOrThrow()
-                }
-            }
-        }
-    }
-    
-    /**
-     * Executes an operation with retry logic and exponential backoff
-     */
-    private suspend fun <T> retryOperation(
-        operationName: String,
-        maxRetries: Int,
-        operation: suspend () -> T
-    ): Result<T> {
-        var currentDelay = config.initialDelay
-        var lastError: Throwable? = null
-        
-        repeat(maxRetries) { attempt ->
-            try {
-                val result = operation()
-                return Result.success(result)
-            } catch (e: Throwable) {
-                lastError = e
-                
-                if (attempt < maxRetries - 1) {
-                    // Wait before retrying with exponential backoff
-                    delay(currentDelay)
-                    
-                    // Calculate next delay with backoff
-                    currentDelay = minOf(
-                        (currentDelay.inWholeMilliseconds * config.backoffMultiplier).toLong().milliseconds,
-                        config.maxDelay
-                    )
-                }
-            }
-        }
-        
-        return Result.failure(lastError ?: Exception("Operation failed after $maxRetries retries"))
-    }
-    
+
     companion object {
         /**
          * Creates a new RetryPlugin instance with the given configuration
@@ -174,12 +118,12 @@ sealed class RetryableException : Exception() {
      * Connection timeout
      */
     class ConnectionTimeout : RetryableException()
-    
+
     /**
      * Device not available
      */
     class DeviceNotAvailable : RetryableException()
-    
+
     /**
      * GATT error
      */

--- a/library/plugins/retry/src/commonTest/kotlin/dev/bluefalcon/plugins/retry/RetryPluginTest.kt
+++ b/library/plugins/retry/src/commonTest/kotlin/dev/bluefalcon/plugins/retry/RetryPluginTest.kt
@@ -1,0 +1,86 @@
+package dev.bluefalcon.plugins.retry
+
+import dev.bluefalcon.core.plugin.RetryableOperation
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for the [RetryPlugin]'s [RetryCapable] decision logic - i.e. that it produces the
+ * expected exponential backoff delays and respects its configured retry budget and predicates.
+ */
+class RetryPluginTest {
+
+    @Test
+    fun `retries connect while attempts remain and applies exponential backoff`() = runTest {
+        val plugin = RetryPlugin.create {
+            maxRetries = 3
+            initialDelay = 100.milliseconds
+            backoffMultiplier = 2.0
+            maxDelay = 10.seconds
+        }
+        val error = IllegalStateException("boom")
+
+        val firstRetryDelay = plugin.retryDelay(RetryableOperation.CONNECT, attempt = 0, error)
+        val secondRetryDelay = plugin.retryDelay(RetryableOperation.CONNECT, attempt = 1, error)
+        val thirdRetryDelay = plugin.retryDelay(RetryableOperation.CONNECT, attempt = 2, error)
+
+        assertEquals(100.milliseconds, firstRetryDelay)
+        assertEquals(200.milliseconds, secondRetryDelay)
+        // maxRetries = 3 means 3 total attempts (1 initial + 2 retries); attempt index 2 has
+        // already exhausted the budget so no further retry should be requested.
+        assertNull(thirdRetryDelay)
+    }
+
+    @Test
+    fun `caps backoff delay at maxDelay`() = runTest {
+        val plugin = RetryPlugin.create {
+            maxRetries = 10
+            initialDelay = 1.seconds
+            backoffMultiplier = 10.0
+            maxDelay = 5.seconds
+        }
+        val error = IllegalStateException("boom")
+
+        val delay = plugin.retryDelay(RetryableOperation.CONNECT, attempt = 3, error)
+
+        assertEquals(5.seconds, delay)
+    }
+
+    @Test
+    fun `does not retry when disabled for that operation type`() = runTest {
+        val plugin = RetryPlugin.create {
+            maxRetries = 5
+            retryConnect = false
+        }
+        val error = IllegalStateException("boom")
+
+        assertNull(plugin.retryDelay(RetryableOperation.CONNECT, attempt = 0, error))
+        // Reads remain enabled by default.
+        assertEquals(500.milliseconds, plugin.retryDelay(RetryableOperation.READ, attempt = 0, error))
+    }
+
+    @Test
+    fun `does not retry when retryOn predicate rejects the error`() = runTest {
+        class RetryableError : Exception()
+
+        val plugin = RetryPlugin.create {
+            retryOn = { it is RetryableError }
+        }
+
+        assertNull(plugin.retryDelay(RetryableOperation.WRITE, attempt = 0, IllegalStateException()))
+        assertEquals(500.milliseconds, plugin.retryDelay(RetryableOperation.WRITE, attempt = 0, RetryableError()))
+    }
+
+    @Test
+    fun `maxRetries of one performs no retries`() = runTest {
+        val plugin = RetryPlugin.create {
+            maxRetries = 1
+        }
+
+        assertNull(plugin.retryDelay(RetryableOperation.CONNECT, attempt = 0, IllegalStateException()))
+    }
+}


### PR DESCRIPTION
Retry plugin:
- Add RetryCapable interface and RetryableOperation enum so plugins can drive real retries through PluginRegistry.
- PluginRegistry now re-invokes the underlying connect/read/write operation on failure instead of just re-reporting the same result.
- RetryPlugin implements RetryCapable with stateless exponential backoff, replacing the old placeholder logic that never retried.
- Add RetryPluginTest and PluginRegistry retry integration tests.

Connection state machine (ADR 0008):
- Add PeripheralConnectionState/DisconnectReason sealed classes.
- BlueFalcon derives per-peripheral state from the existing connectionStateUpdates/serviceDiscoveryUpdates flows, with no engine changes required.
- Add connectionStates, peripheralState(), and connectionStateFlow() APIs; connectionStateFlow is a StateFlow so late subscribers see the current state immediately instead of waiting for the next event.
- Add PeripheralConnectionStateTest covering every transition.